### PR TITLE
Fix shared_streams format rollback

### DIFF
--- a/database/migrations/2025_09_21_000000_add_parent_id_to_playlists.php
+++ b/database/migrations/2025_09_21_000000_add_parent_id_to_playlists.php
@@ -48,7 +48,7 @@ return new class extends Migration {
         });
 
         Schema::table('shared_streams', function (Blueprint $table) {
-            //
+            $table->string('format')->nullable()->default(null)->change();
         });
 
         Schema::table('playlists', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- restore the original default for `format` when rolling back shared_streams changes

## Testing
- `vendor/bin/pest` *(fails: Database file at path [/workspace/m3u-editor/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6f58be348321a28955a9adbcee6b