### PR TITLE
Handle missing parent playlist in SyncPlaylistChildren job

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 /**
@@ -64,6 +65,13 @@ class SyncPlaylistChildren implements ShouldQueue, ShouldBeUnique
     public function handle(): void
     {
         $parent = $this->playlist->fresh();
+
+        if (! $parent) {
+            Log::warning("SyncPlaylistChildren: Parent playlist {$this->playlist->id} not found, clearing queued flag and aborting child sync.");
+            Cache::forget("playlist-sync:{$this->playlist->id}");
+            Cache::forget("playlist-sync:{$this->playlist->id}:queued");
+            return;
+        }
 
         try {
             if (empty($this->changes)) {


### PR DESCRIPTION
## Summary
- prevent `SyncPlaylistChildren` job from running when parent playlist is missing
- clear queued sync flags and log when parent playlist not found

## Testing
- `composer install --no-interaction --no-progress --ansi`
- `php artisan test` *(fails: Database file at path [/workspace/m3u-editor/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6f672d8883219733298708762ebf