### PR TITLE
Set lock timeout for playlist sync jobs

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -24,6 +24,12 @@ class SyncPlaylistChildren implements ShouldQueue, ShouldBeUnique
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
+     * Release the unique lock after an hour so a new sync can
+     * run if a previous job fails or never completes.
+     */
+    public $uniqueFor = 3600;
+
+    /**
      * @param  array<string, array<int, string>>  $changes
      */
     public function __construct(public Playlist $playlist, public array $changes = [])


### PR DESCRIPTION
## Summary
- allow SyncPlaylistChildren job to release its unique lock after an hour so stalled jobs can be retried

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: Database file at path [database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6f927b5083219315ca00e69cdc9d