### PR TITLE
fix undefined $copiedPath in DuplicatePlaylist job

### DIFF
--- a/app/Jobs/DuplicatePlaylist.php
+++ b/app/Jobs/DuplicatePlaylist.php
@@ -31,6 +31,8 @@ class DuplicatePlaylist implements ShouldQueue
     public function handle(): void
     {
         DB::beginTransaction();
+        $copiedPath = null;
+
         try {
             // Get the base playlist
             $playlist = $this->playlist;
@@ -49,9 +51,9 @@ class DuplicatePlaylist implements ShouldQueue
                 'name',
                 'uuid',
                 'short_urls_enabled',
-                'short_urls'
+                'short_urls',
             ]);
-            $newPlaylist->name = $this->name ?? $playlist->name . ' (Copy)';
+            $newPlaylist->name = $this->name ?? $playlist->name.' (Copy)';
             $newPlaylist->uuid = Str::orderedUuid()->toString();
             $newPlaylist->created_at = $now;
             $newPlaylist->updated_at = $now;
@@ -82,7 +84,7 @@ class DuplicatePlaylist implements ShouldQueue
                     $newChannel->playlist_id = $newPlaylist->id;
                     $newChannel->created_at = $now;
                     $newChannel->updated_at = $now;
-                    $newChannel->source_id = $channel->source_id ?? 'ch-' . $channel->id;
+                    $newChannel->source_id = $channel->source_id ?? 'ch-'.$channel->id;
                     $newChannel->save();
 
                     // Copy the channel failovers
@@ -108,7 +110,7 @@ class DuplicatePlaylist implements ShouldQueue
                 $newCategory->playlist_id = $newPlaylist->id;
                 $newCategory->created_at = $now;
                 $newCategory->updated_at = $now;
-                $newCategory->source_category_id = $category->source_category_id ?? 'cat-' . $category->id;
+                $newCategory->source_category_id = $category->source_category_id ?? 'cat-'.$category->id;
                 $newCategory->save();
 
                 // Copy the category series
@@ -122,7 +124,7 @@ class DuplicatePlaylist implements ShouldQueue
                     $newSeries->playlist_id = $newPlaylist->id;
                     $newSeries->created_at = $now;
                     $newSeries->updated_at = $now;
-                    $newSeries->source_series_id = $series->source_series_id ?? 'series-' . $series->id;
+                    $newSeries->source_series_id = $series->source_series_id ?? 'series-'.$series->id;
                     $newSeries->save();
 
                     // Copy the series seasons
@@ -138,7 +140,7 @@ class DuplicatePlaylist implements ShouldQueue
                         $newSeason->playlist_id = $newPlaylist->id;
                         $newSeason->created_at = $now;
                         $newSeason->updated_at = $now;
-                        $newSeason->source_season_id = $season->source_season_id ?? 'season-' . $season->id;
+                        $newSeason->source_season_id = $season->source_season_id ?? 'season-'.$season->id;
                         $newSeason->save();
 
                         // Copy the season episodes
@@ -154,7 +156,7 @@ class DuplicatePlaylist implements ShouldQueue
                             $newEpisode->playlist_id = $newPlaylist->id;
                             $newEpisode->created_at = $now;
                             $newEpisode->updated_at = $now;
-                            $newEpisode->source_episode_id = $episode->source_episode_id ?? 'ep-' . $episode->id;
+                            $newEpisode->source_episode_id = $episode->source_episode_id ?? 'ep-'.$episode->id;
                             $newEpisode->save();
                         }
                     }
@@ -172,7 +174,7 @@ class DuplicatePlaylist implements ShouldQueue
                 $newChannel->playlist_id = $newPlaylist->id;
                 $newChannel->created_at = $now;
                 $newChannel->updated_at = $now;
-                $newChannel->source_id = $channel->source_id ?? 'ch-' . $channel->id;
+                $newChannel->source_id = $channel->source_id ?? 'ch-'.$channel->id;
                 $newChannel->save();
 
                 foreach ($channel->failovers as $failover) {
@@ -191,7 +193,7 @@ class DuplicatePlaylist implements ShouldQueue
                 $newSeries->playlist_id = $newPlaylist->id;
                 $newSeries->created_at = $now;
                 $newSeries->updated_at = $now;
-                $newSeries->source_series_id = $series->source_series_id ?? 'series-' . $series->id;
+                $newSeries->source_series_id = $series->source_series_id ?? 'series-'.$series->id;
                 $newSeries->save();
 
                 foreach ($series->seasons()->lazy() as $season) {
@@ -201,7 +203,7 @@ class DuplicatePlaylist implements ShouldQueue
                     $newSeason->playlist_id = $newPlaylist->id;
                     $newSeason->created_at = $now;
                     $newSeason->updated_at = $now;
-                    $newSeason->source_season_id = $season->source_season_id ?? 'season-' . $season->id;
+                    $newSeason->source_season_id = $season->source_season_id ?? 'season-'.$season->id;
                     $newSeason->save();
 
                     foreach ($season->episodes()->lazy() as $episode) {
@@ -211,7 +213,7 @@ class DuplicatePlaylist implements ShouldQueue
                         $newEpisode->playlist_id = $newPlaylist->id;
                         $newEpisode->created_at = $now;
                         $newEpisode->updated_at = $now;
-                        $newEpisode->source_episode_id = $episode->source_episode_id ?? 'ep-' . $episode->id;
+                        $newEpisode->source_episode_id = $episode->source_episode_id ?? 'ep-'.$episode->id;
                         $newEpisode->save();
                     }
                 }
@@ -223,7 +225,6 @@ class DuplicatePlaylist implements ShouldQueue
             // This prevents conflicts with the unique constraint.
 
             // Copy uploaded file
-            $copiedPath = null;
             if ($playlist->uploads && Storage::disk('local')->exists($playlist->uploads)) {
                 Storage::disk('local')->makeDirectory($newPlaylist->folder_path);
                 if (! Storage::disk('local')->copy($playlist->uploads, $newPlaylist->file_path)) {


### PR DESCRIPTION
## Summary
- initialize `$copiedPath` before trying to duplicate playlists so cleanup can always run

## Testing
- `vendor/bin/pint app/Jobs/DuplicatePlaylist.php`
- `vendor/bin/pest` *(fails: Database file at path [database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb94a4bc1c83218fff82c76de946b7