### PR TITLE
revert playlist duplication changes

### DIFF
--- a/app/Jobs/DuplicatePlaylist.php
+++ b/app/Jobs/DuplicatePlaylist.php
@@ -49,9 +49,9 @@ class DuplicatePlaylist implements ShouldQueue
                 'name',
                 'uuid',
                 'short_urls_enabled',
-                'short_urls'
+                'short_urls',
             ]);
-            $newPlaylist->name = $this->name ?? $playlist->name . ' (Copy)';
+            $newPlaylist->name = $this->name ?? $playlist->name.' (Copy)';
             $newPlaylist->uuid = Str::orderedUuid()->toString();
             $newPlaylist->created_at = $now;
             $newPlaylist->updated_at = $now;
@@ -82,7 +82,6 @@ class DuplicatePlaylist implements ShouldQueue
                     $newChannel->playlist_id = $newPlaylist->id;
                     $newChannel->created_at = $now;
                     $newChannel->updated_at = $now;
-                    $newChannel->source_id = $channel->source_id ?? 'ch-' . $channel->id;
                     $newChannel->save();
 
                     // Copy the channel failovers
@@ -108,7 +107,6 @@ class DuplicatePlaylist implements ShouldQueue
                 $newCategory->playlist_id = $newPlaylist->id;
                 $newCategory->created_at = $now;
                 $newCategory->updated_at = $now;
-                $newCategory->source_category_id = $category->source_category_id ?? 'cat-' . $category->id;
                 $newCategory->save();
 
                 // Copy the category series
@@ -122,7 +120,6 @@ class DuplicatePlaylist implements ShouldQueue
                     $newSeries->playlist_id = $newPlaylist->id;
                     $newSeries->created_at = $now;
                     $newSeries->updated_at = $now;
-                    $newSeries->source_series_id = $series->source_series_id ?? 'series-' . $series->id;
                     $newSeries->save();
 
                     // Copy the series seasons
@@ -138,7 +135,6 @@ class DuplicatePlaylist implements ShouldQueue
                         $newSeason->playlist_id = $newPlaylist->id;
                         $newSeason->created_at = $now;
                         $newSeason->updated_at = $now;
-                        $newSeason->source_season_id = $season->source_season_id ?? 'season-' . $season->id;
                         $newSeason->save();
 
                         // Copy the season episodes
@@ -154,7 +150,6 @@ class DuplicatePlaylist implements ShouldQueue
                             $newEpisode->playlist_id = $newPlaylist->id;
                             $newEpisode->created_at = $now;
                             $newEpisode->updated_at = $now;
-                            $newEpisode->source_episode_id = $episode->source_episode_id ?? 'ep-' . $episode->id;
                             $newEpisode->save();
                         }
                     }
@@ -172,7 +167,6 @@ class DuplicatePlaylist implements ShouldQueue
                 $newChannel->playlist_id = $newPlaylist->id;
                 $newChannel->created_at = $now;
                 $newChannel->updated_at = $now;
-                $newChannel->source_id = $channel->source_id ?? 'ch-' . $channel->id;
                 $newChannel->save();
 
                 foreach ($channel->failovers as $failover) {
@@ -191,7 +185,6 @@ class DuplicatePlaylist implements ShouldQueue
                 $newSeries->playlist_id = $newPlaylist->id;
                 $newSeries->created_at = $now;
                 $newSeries->updated_at = $now;
-                $newSeries->source_series_id = $series->source_series_id ?? 'series-' . $series->id;
                 $newSeries->save();
 
                 foreach ($series->seasons()->lazy() as $season) {
@@ -201,7 +194,6 @@ class DuplicatePlaylist implements ShouldQueue
                     $newSeason->playlist_id = $newPlaylist->id;
                     $newSeason->created_at = $now;
                     $newSeason->updated_at = $now;
-                    $newSeason->source_season_id = $season->source_season_id ?? 'season-' . $season->id;
                     $newSeason->save();
 
                     foreach ($season->episodes()->lazy() as $episode) {
@@ -211,7 +203,6 @@ class DuplicatePlaylist implements ShouldQueue
                         $newEpisode->playlist_id = $newPlaylist->id;
                         $newEpisode->created_at = $now;
                         $newEpisode->updated_at = $now;
-                        $newEpisode->source_episode_id = $episode->source_episode_id ?? 'ep-' . $episode->id;
                         $newEpisode->save();
                     }
                 }
@@ -238,11 +229,15 @@ class DuplicatePlaylist implements ShouldQueue
             DB::commit();
 
             // Send notification
-            Notification::make()
-                ->success()
-                ->title('Playlist Duplicated')
-                ->body("\"{$playlist->name}\" has been duplicated successfully.")
-                ->broadcast($playlist->user);
+            try {
+                Notification::make()
+                    ->success()
+                    ->title('Playlist Duplicated')
+                    ->body("\"{$playlist->name}\" has been duplicated successfully.")
+                    ->broadcast($playlist->user);
+            } catch (\Throwable $broadcastError) {
+                logger()->warning('Broadcast failed: '.$broadcastError->getMessage());
+            }
             Notification::make()
                 ->success()
                 ->title('Playlist Duplicated')
@@ -259,11 +254,15 @@ class DuplicatePlaylist implements ShouldQueue
             logger()->error("Error duplicating \"{$this->playlist->name}\": {$e->getMessage()}");
 
             // Send notification
-            Notification::make()
-                ->danger()
-                ->title("Error duplicating \"{$this->playlist->name}\"")
-                ->body('Please view your notifications for details.')
-                ->broadcast($this->playlist->user);
+            try {
+                Notification::make()
+                    ->danger()
+                    ->title("Error duplicating \"{$this->playlist->name}\"")
+                    ->body('Please view your notifications for details.')
+                    ->broadcast($this->playlist->user);
+            } catch (\Throwable $broadcastError) {
+                logger()->warning('Broadcast failed: '.$broadcastError->getMessage());
+            }
             Notification::make()
                 ->danger()
                 ->title("Error duplicating \"{$this->playlist->name}\"")

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,22 +2,23 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\DispatchesPlaylistSync;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Models\Concerns\DispatchesPlaylistSync;
 
 class Category extends Model
 {
-    use HasFactory;
     use DispatchesPlaylistSync;
+    use HasFactory;
 
     public const SOURCE_INDEX = ['playlist_id', 'source_category_id'];
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_category_id ?? 'cat-' . $this->id;
+        $source = $this->source_category_id ?? 'cat-'.$this->id;
+
         return ['categories' => [$source]];
     }
 

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -2,21 +2,22 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\DispatchesPlaylistSync;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process as SymfonyProcess;
-use App\Models\Concerns\DispatchesPlaylistSync;
 
 class Episode extends Model
 {
-    use HasFactory;
     use DispatchesPlaylistSync;
+    use HasFactory;
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_episode_id ?? 'ep-' . $this->id;
+        $source = $this->source_episode_id ?? 'ep-'.$this->id;
+
         return ['episodes' => [$source]];
     }
 
@@ -97,6 +98,7 @@ class Episode extends Model
             );
             if ($hasErrors) {
                 Log::error("Error running ffprobe for episode \"{$this->title}\": {$errors}");
+
                 return [];
             }
             $json = json_decode($output, true);
@@ -120,11 +122,13 @@ class Episode extends Model
                         ];
                     }
                 }
+
                 return $streamStats;
             }
         } catch (\Exception $e) {
             Log::error("Error running ffprobe for episode \"{$this->title}\": {$e->getMessage()}");
         }
+
         return [];
     }
 
@@ -133,7 +137,7 @@ class Episode extends Model
      */
     public function getAddedAttribute($value)
     {
-        if (!$value) {
+        if (! $value) {
             return null;
         }
 

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -2,22 +2,23 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\DispatchesPlaylistSync;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Models\Concerns\DispatchesPlaylistSync;
 
 class Season extends Model
 {
-    use HasFactory;
     use DispatchesPlaylistSync;
+    use HasFactory;
 
     public const SOURCE_INDEX = ['playlist_id', 'source_season_id'];
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_season_id ?? 'season-' . $this->id;
+        $source = $this->source_season_id ?? 'season-'.$this->id;
+
         return ['seasons' => [$source]];
     }
 


### PR DESCRIPTION
## Summary
- restore upstream playlist duplication workflow without overriding `source_*_id` values
- revert `source_*_id` fields to integer casts and drop unnecessary migration
- guard against broadcast failures during playlist duplication

## Testing
- `vendor/bin/pint app/Jobs/DuplicatePlaylist.php`
- `vendor/bin/pest` *(fails: Database file at path [/workspace/m3u-editor/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb94a4bc1c83218fff82c76de946b7