### PR TITLE
Fix group is_custom column mismatch and start child sync immediately

### DIFF
--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -107,7 +107,7 @@ class GroupResource extends Resource
                     ->numeric()
                     ->toggleable()
                     ->sortable(),
-                Tables\Columns\IconColumn::make('custom')
+                Tables\Columns\IconColumn::make('is_custom')
                     ->label('Custom')
                     ->icon(fn(string $state): string => match ($state) {
                         '1' => 'heroicon-o-check-circle',
@@ -257,7 +257,7 @@ class GroupResource extends Resource
                         ->modalSubmitActionLabel('Yes, disable now'),
 
                     Tables\Actions\DeleteAction::make()
-                        ->hidden(fn($record) => !$record->custom),
+                        ->hidden(fn($record) => !$record->is_custom),
                 ])->button()->hiddenLabel()->size('sm'),
             ], position: Tables\Enums\ActionsPosition::BeforeCells)
             ->bulkActions([

--- a/app/Filament/Resources/GroupResource/Pages/ListGroups.php
+++ b/app/Filament/Resources/GroupResource/Pages/ListGroups.php
@@ -21,7 +21,7 @@ class ListGroups extends ListRecords
             Actions\CreateAction::make()
                 ->using(function (array $data, string $model): Model {
                     $data['user_id'] = auth()->id();
-                    $data['custom'] = true;
+                    $data['is_custom'] = true;
                     return $model::create($data);
                 })
                 ->successNotification(

--- a/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
+++ b/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
@@ -145,7 +145,7 @@ class ViewGroup extends ViewRecord
                     ->modalSubmitActionLabel('Yes, disable now'),
 
                 Actions\DeleteAction::make()
-                    ->hidden(fn($record) => !$record->custom),
+                    ->hidden(fn($record) => !$record->is_custom),
             ])->button()->label('Actions'),
         ];
     }

--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -89,7 +89,8 @@ class PlaylistResource extends Resource
             ->modifyQueryUsing(function (Builder $query) {
                 $query->withCount('enabled_live_channels')
                     ->withCount('enabled_vod_channels')
-                    ->withCount('enabled_series');
+                    ->withCount('enabled_series')
+                    ->orderByRaw('COALESCE(parent_id, id), parent_id IS NOT NULL, id');
             })
             ->columns([
                 Tables\Columns\TextColumn::make('id')

--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -47,8 +47,8 @@ class SyncPlaylistChildren implements ShouldQueue, ShouldBeUnique
 
     /**
      * Debounce child sync dispatches by caching change identifiers per playlist
-     * and queuing a single job after a short delay. Changes and the queued flag
-     * share a five‑second TTL so rapid edits merge into one job and only one
+     * and queuing a single job immediately. Changes and the queued flag
+     * share a short TTL so rapid edits merge into one job and only one
      * dispatch is scheduled at a time.
      *
      * @param  array<string, array<int, string>>  $changes
@@ -66,7 +66,7 @@ class SyncPlaylistChildren implements ShouldQueue, ShouldBeUnique
         // short window that matches the change-cache TTL. The flag is cleared
         // at the end of the job so subsequent edits can enqueue another sync.
         if (Cache::add("{$key}:queued", true, self::DEBOUNCE_TTL)) {
-            self::dispatchAfterResponse($playlist)->delay(now()->addSeconds(self::DEBOUNCE_TTL));
+            self::dispatch($playlist);
         }
     }
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -31,6 +31,7 @@ class Group extends Model
         'user_id' => 'integer',
         'playlist_id' => 'integer',
         'sort_order' => 'integer',
+        'is_custom' => 'boolean',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -241,7 +241,7 @@ class Playlist extends Model
 
             $lock = Cache::lock("sync-playlist-{$playlist->id}", 5);
             if ($lock->get()) {
-                SyncPlaylistChildren::dispatchAfterResponse($playlist);
+                SyncPlaylistChildren::dispatch($playlist);
             }
         });
     }

--- a/database/migrations/2025_06_20_000000_rename_custom_to_is_custom_on_groups_table.php
+++ b/database/migrations/2025_06_20_000000_rename_custom_to_is_custom_on_groups_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE groups RENAME COLUMN custom TO is_custom');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE groups RENAME COLUMN is_custom TO custom');
+    }
+};


### PR DESCRIPTION
## Summary
- Cast `is_custom` boolean on groups model
- Use `is_custom` in group resources and pages
- Add migration to rename `custom` column to `is_custom`
- Queue child playlist sync jobs immediately instead of waiting for a delay
- Sort playlists so child entries appear directly beneath their parents

## Testing
- `php artisan test` *(fails: PusherException – required dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbce3ccec483218bfdfeb098c727c1