### PR TITLE
fix group custom column lookups

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -845,7 +845,7 @@ class ProcessM3uImport implements ShouldQueue
                         'name_internal' => $groupName ?? '',
                         'playlist_id' => $playlistId,
                         'user_id' => $userId,
-                        'custom' => false,
+                        'is_custom' => false,
                     ])->first();
                     if (!$group) {
                         $data = [

--- a/app/Jobs/ProcessM3uImportComplete.php
+++ b/app/Jobs/ProcessM3uImportComplete.php
@@ -74,7 +74,7 @@ class ProcessM3uImportComplete implements ShouldQueue
 
         // Get the removed groups
         $removedGroups = Group::where([
-            ['custom', false],
+            ['is_custom', false],
             ['playlist_id', $playlist->id],
             ['import_batch_no', '!=', $this->batchNo],
         ]);


### PR DESCRIPTION
## Summary
- use `is_custom` column when querying for groups

## Testing
- `./vendor/bin/pest` *(fails: 121 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd46111e083219ad05108cb8d8a51