### PR TITLE
Prevent duplication of child playlists

### DIFF
--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -321,6 +321,7 @@ class PlaylistResource extends Resource
                                 ->duration(3000)
                                 ->send();
                         })
+                        ->hidden(fn($record) => $record->parent_id !== null)
                         ->requiresConfirmation()
                         ->icon('heroicon-o-document-duplicate')
                         ->modalIcon('heroicon-o-document-duplicate')
@@ -668,6 +669,7 @@ class PlaylistResource extends Resource
                             ->duration(3000)
                             ->send();
                     })
+                    ->hidden(fn($record) => $record->parent_id !== null)
                     ->requiresConfirmation()
                     ->icon('heroicon-o-document-duplicate')
                     ->modalIcon('heroicon-o-document-duplicate')

--- a/app/Jobs/DuplicatePlaylist.php
+++ b/app/Jobs/DuplicatePlaylist.php
@@ -38,9 +38,9 @@ class DuplicatePlaylist implements ShouldQueue
             // Get the base playlist
             $playlist = $this->playlist;
 
-            // Prevent creating nested child playlists
-            if ($this->withSync && $playlist->parent_id) {
-                throw new \InvalidArgumentException('Child playlists cannot be duplicated with sync.');
+            // Prevent duplicating child playlists altogether
+            if ($playlist->parent_id) {
+                throw new \InvalidArgumentException('Child playlists cannot be duplicated.');
             }
 
             // Current timestamp

--- a/tests/Feature/PlaylistSyncTest.php
+++ b/tests/Feature/PlaylistSyncTest.php
@@ -193,12 +193,12 @@ it('syncs multiple custom channels without source ids', function () {
     expect($child->channels()->where('name', 'Two')->exists())->toBeTrue();
 });
 
-it('prevents duplicating child playlist with sync', function () {
+it('prevents duplicating a child playlist', function () {
     $playlist = Playlist::factory()->create();
     (new DuplicatePlaylist($playlist, withSync: true))->handle();
     $child = Playlist::where('parent_id', $playlist->id)->first();
 
-    (new DuplicatePlaylist($child, withSync: true))->handle();
+    (new DuplicatePlaylist($child))->handle();
 })->throws(InvalidArgumentException::class);
 
 it('syncs uploaded files to child playlists', function () {


### PR DESCRIPTION
## Summary
- block duplication when playlist already has a parent
- hide duplicate actions for child playlists in Filament UI
- adjust tests to expect duplication of child playlists to fail

## Testing
- `composer install --no-interaction --no-progress`
- `BROADCAST_DRIVER=log ./vendor/bin/pest` *(fails: PusherException in vendor/pusher/pusher-php-server/src/Pusher.php:63)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdb9a15888321892898308f004231