### PR TITLE
fix missing unique constraint for group upserts

### DIFF
--- a/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
+++ b/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
@@ -24,6 +24,10 @@ return new class extends Migration {
             $table->index(['playlist_id', 'source_category_id']);
         });
 
+        Schema::table('groups', function (Blueprint $table) {
+            $table->unique(['playlist_id', 'name_internal'], 'groups_playlist_id_name_internal_unique');
+        });
+
         Schema::table('series', function (Blueprint $table) {
             $table->index(['playlist_id', 'source_series_id']);
         });
@@ -41,6 +45,10 @@ return new class extends Migration {
 
         Schema::table('series', function (Blueprint $table) {
             $table->dropIndex(['playlist_id', 'source_series_id']);
+        });
+
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropUnique('groups_playlist_id_name_internal_unique');
         });
 
         Schema::table('categories', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- add unique index on groups playlist and internal name columns for upserts

## Testing
- `./vendor/bin/pest` *(fails: Tests: 121 failed, 1 passed (1 assertions))*

------
https://chatgpt.com/codex/tasks/task_e_68bbdc69f3808321b3d4a115d2434973