### PR TITLE
Set child playlists pending before sync

### DIFF
--- a/app/Listeners/SyncListener.php
+++ b/app/Listeners/SyncListener.php
@@ -36,6 +36,11 @@ class SyncListener
             });
 
             if (!$event->model->parent_id && $event->model->children()->exists()) {
+                $event->model->children()->update([
+                    'status' => Status::Pending,
+                    'processing' => false,
+                ]);
+
                 dispatch(new \App\Jobs\SyncPlaylistChildren($event->model));
             }
         }


### PR DESCRIPTION
## Summary
- Mark child playlists as pending and not processing before syncing children

## Testing
- `vendor/bin/pest` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68bbea8800188321bd88e1fdae79fa2b