### PR TITLE
Update playlist child sync status

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -119,6 +119,16 @@ class ProcessM3uImport implements ShouldQueue
             'series_progress' => 0,
         ]);
 
+        // Mark child playlists as pending while the parent syncs
+        if (! $this->playlist->parent_id && $this->playlist->children()->exists()) {
+            $this->playlist->children()->update([
+                'status' => Status::Pending,
+                'processing' => true,
+                'progress' => 0,
+                'series_progress' => 0,
+            ]);
+        }
+
         // Determine if using Xtream API or M3U+
         if ($this->playlist->xtream) {
             $this->processXtreamApi();


### PR DESCRIPTION
## Summary
- track progress of child playlist syncs
- set status and timestamps based on sync outcomes
- mark child playlists as pending while parent syncs

## Testing
- `php -l app/Jobs/ProcessM3uImport.php`
- `php -l app/Jobs/SyncPlaylistChildren.php`
- `composer install --no-progress --no-interaction`
- `./vendor/bin/pest --configuration phpunit.xml` *(fails: Tests: 121 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbea8c02788321a77c13a5809584ae