### PR TITLE
Defer child playlist sync until parent series completes

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -1008,6 +1008,7 @@ class ProcessM3uImport implements ShouldQueue
             start: $start,
             maxHit: $this->maxItemsHit,
             isNew: $this->isNew,
+            hasSeries: (bool) $seriesCategories,
         );
 
         // Add series processing to the chain, if passed in


### PR DESCRIPTION
## Summary
- avoid firing SyncCompleted until series processing finishes
- keep playlists processing when additional series jobs remain
- test child playlists remain pending during parent series sync

## Testing
- `./vendor/bin/pest` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*
- `./vendor/bin/pest tests/Feature/PlaylistSyncTest.php` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*


------
https://chatgpt.com/codex/tasks/task_e_68bbf4013a20832191bbe769601463b0