### PR TITLE
Remove redundant eager load for group channels

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -167,7 +167,7 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
     private function syncGroups(Playlist $parent, Playlist $child): void
     {
         $parentGroupNames = [];
-        $parent->groups()->with('channels.failovers')->chunkById(100, function ($groups) use ($child, &$parentGroupNames) {
+        $parent->groups()->chunkById(100, function ($groups) use ($child, &$parentGroupNames) {
             $groupRows = [];
             foreach ($groups as $group) {
                 $parentGroupNames[] = $group->name_internal;


### PR DESCRIPTION
## Summary
- Avoid eager-loading group channels when syncing playlist children

## Testing
- `vendor/bin/pest` *(fails: Pusher\Pusher requires dependencies; 122 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfba5d12483219d5e16119c60b4aa