### PR TITLE
Log missing channels when syncing playlist groups

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -213,7 +213,13 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
                 })->delete();
                 $childChannels = $child->channels()->where('group_id', $childGroupId)->whereIn('source_id', $channelSources)->get()->keyBy('source_id');
                 foreach ($failovers as $source => $items) {
-                    $childChannel = $childChannels[$source];
+                    $childChannel = $childChannels->get($source);
+                    if (! $childChannel) {
+                        Log::info("SyncPlaylistChildren: Child channel not found for source '{$source}' on playlist {$child->id}");
+
+                        continue;
+                    }
+
                     $childChannel->failovers()->delete();
                     foreach ($items as $failover) {
                         $newFailover = $failover->replicate(except: ['id', 'channel_id', 'created_at', 'updated_at']);


### PR DESCRIPTION
## Summary
- Use collection get() when accessing child channels during group sync
- Log and skip when a channel for failovers is missing

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/pest` *(fails: No such file or directory)*
- `php -l app/Jobs/SyncPlaylistChildren.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbfbb6c4c48321a887fd497980d822