### PR TITLE
Use unique playlist/source index on categories

### DIFF
--- a/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
+++ b/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
@@ -21,7 +21,10 @@ return new class extends Migration {
         });
 
         Schema::table('categories', function (Blueprint $table) {
-            $table->index(['playlist_id', 'source_category_id']);
+            $table->unique(
+                ['playlist_id', 'source_category_id'],
+                'categories_playlist_id_source_category_id_unique'
+            );
         });
 
         Schema::table('groups', function (Blueprint $table) {
@@ -52,7 +55,7 @@ return new class extends Migration {
         });
 
         Schema::table('categories', function (Blueprint $table) {
-            $table->dropIndex(['playlist_id', 'source_category_id']);
+            $table->dropUnique('categories_playlist_id_source_category_id_unique');
         });
 
         Schema::table('shared_streams', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- enforce unique composite index on `categories` for playlist/source ids within existing migration
- remove now-unnecessary migration file

## Testing
- `BROADCAST_CONNECTION=log php artisan test tests/Feature/SourceIndexesTest.php`
- `BROADCAST_CONNECTION=log php artisan test` *(fails: Tests\Unit\MergeChannelsTest::it does not merge channels with empty stream ids)*

------
https://chatgpt.com/codex/tasks/task_e_68bc006f31ec83219c08d7fa5e39d682