### PR TITLE
Fix upsert conflicts for series and seasons

### DIFF
--- a/app/Listeners/SyncListener.php
+++ b/app/Listeners/SyncListener.php
@@ -40,8 +40,8 @@ class SyncListener
                     'status' => Status::Pending,
                     'processing' => false,
                 ]);
-
-                dispatch(new \App\Jobs\SyncPlaylistChildren($event->model));
+            } elseif ($event->model->parent_id && ! $event->model->parent->processing) {
+                dispatch(new \App\Jobs\SyncPlaylistChildren($event->model->parent));
             }
         }
         if ($event->model instanceof \App\Models\Epg) {

--- a/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
+++ b/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
@@ -32,22 +32,28 @@ return new class extends Migration {
         });
 
         Schema::table('series', function (Blueprint $table) {
-            $table->index(['playlist_id', 'source_series_id']);
+            $table->unique(
+                ['playlist_id', 'source_series_id'],
+                'series_playlist_id_source_series_id_unique'
+            );
         });
 
         Schema::table('seasons', function (Blueprint $table) {
-            $table->index(['playlist_id', 'source_season_id']);
+            $table->unique(
+                ['playlist_id', 'source_season_id'],
+                'seasons_playlist_id_source_season_id_unique'
+            );
         });
     }
 
     public function down(): void
     {
         Schema::table('seasons', function (Blueprint $table) {
-            $table->dropIndex(['playlist_id', 'source_season_id']);
+            $table->dropUnique('seasons_playlist_id_source_season_id_unique');
         });
 
         Schema::table('series', function (Blueprint $table) {
-            $table->dropIndex(['playlist_id', 'source_series_id']);
+            $table->dropUnique('series_playlist_id_source_series_id_unique');
         });
 
         Schema::table('groups', function (Blueprint $table) {

--- a/tests/Feature/PlaylistSyncTest.php
+++ b/tests/Feature/PlaylistSyncTest.php
@@ -546,6 +546,16 @@ it('dispatches child sync after parent provider sync', function () {
     Queue::assertPushed(SyncPlaylistChildren::class, 1);
 });
 
+it('dispatches child sync after child provider sync', function () {
+    $parent = Playlist::factory()->create();
+    (new DuplicatePlaylist($parent, withSync: true))->handle();
+    $child = Playlist::where('parent_id', $parent->id)->first();
+
+    Queue::fake();
+    event(new SyncCompleted($child));
+    Queue::assertPushed(SyncPlaylistChildren::class, fn ($job) => $job->playlist->is($parent));
+});
+
 it('dispatches a single sync job for rapid parent saves', function () {
     $playlist = Playlist::factory()->create();
     (new DuplicatePlaylist($playlist, withSync: true))->handle();


### PR DESCRIPTION
## Summary
- add composite unique index for series upserts
- add composite unique index for season upserts
- run child sync only after parent and child provider syncs complete

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0f95a1588321aac0fb2054e16504