### PR TITLE
Ensure series upsert uses unique index

### DIFF
--- a/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
+++ b/database/migrations/2025_09_06_000000_add_parent_id_to_playlists.php
@@ -20,49 +20,65 @@ return new class extends Migration {
             $table->string('format')->default('ts')->change();
         });
 
-        Schema::table('categories', function (Blueprint $table) {
-            $table->unique(
-                ['playlist_id', 'source_category_id'],
-                'categories_playlist_id_source_category_id_unique'
-            );
-        });
+        if (! Schema::hasIndex('categories', 'categories_playlist_id_source_category_id_unique')) {
+            Schema::table('categories', function (Blueprint $table) {
+                $table->unique(
+                    ['playlist_id', 'source_category_id'],
+                    'categories_playlist_id_source_category_id_unique'
+                );
+            });
+        }
 
-        Schema::table('groups', function (Blueprint $table) {
-            $table->unique(['playlist_id', 'name_internal'], 'groups_playlist_id_name_internal_unique');
-        });
+        if (! Schema::hasIndex('groups', 'groups_playlist_id_name_internal_unique')) {
+            Schema::table('groups', function (Blueprint $table) {
+                $table->unique(['playlist_id', 'name_internal'], 'groups_playlist_id_name_internal_unique');
+            });
+        }
 
-        Schema::table('series', function (Blueprint $table) {
-            $table->unique(
-                ['playlist_id', 'source_series_id'],
-                'series_playlist_id_source_series_id_unique'
-            );
-        });
+        if (! Schema::hasIndex('series', 'series_playlist_id_source_series_id_unique')) {
+            Schema::table('series', function (Blueprint $table) {
+                $table->unique(
+                    ['playlist_id', 'source_series_id'],
+                    'series_playlist_id_source_series_id_unique'
+                );
+            });
+        }
 
-        Schema::table('seasons', function (Blueprint $table) {
-            $table->unique(
-                ['playlist_id', 'source_season_id'],
-                'seasons_playlist_id_source_season_id_unique'
-            );
-        });
+        if (! Schema::hasIndex('seasons', 'seasons_playlist_id_source_season_id_unique')) {
+            Schema::table('seasons', function (Blueprint $table) {
+                $table->unique(
+                    ['playlist_id', 'source_season_id'],
+                    'seasons_playlist_id_source_season_id_unique'
+                );
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('seasons', function (Blueprint $table) {
-            $table->dropUnique('seasons_playlist_id_source_season_id_unique');
-        });
+        if (Schema::hasIndex('seasons', 'seasons_playlist_id_source_season_id_unique')) {
+            Schema::table('seasons', function (Blueprint $table) {
+                $table->dropUnique('seasons_playlist_id_source_season_id_unique');
+            });
+        }
 
-        Schema::table('series', function (Blueprint $table) {
-            $table->dropUnique('series_playlist_id_source_series_id_unique');
-        });
+        if (Schema::hasIndex('series', 'series_playlist_id_source_series_id_unique')) {
+            Schema::table('series', function (Blueprint $table) {
+                $table->dropUnique('series_playlist_id_source_series_id_unique');
+            });
+        }
 
-        Schema::table('groups', function (Blueprint $table) {
-            $table->dropUnique('groups_playlist_id_name_internal_unique');
-        });
+        if (Schema::hasIndex('groups', 'groups_playlist_id_name_internal_unique')) {
+            Schema::table('groups', function (Blueprint $table) {
+                $table->dropUnique('groups_playlist_id_name_internal_unique');
+            });
+        }
 
-        Schema::table('categories', function (Blueprint $table) {
-            $table->dropUnique('categories_playlist_id_source_category_id_unique');
-        });
+        if (Schema::hasIndex('categories', 'categories_playlist_id_source_category_id_unique')) {
+            Schema::table('categories', function (Blueprint $table) {
+                $table->dropUnique('categories_playlist_id_source_category_id_unique');
+            });
+        }
 
         Schema::table('shared_streams', function (Blueprint $table) {
             $table->string('format')->nullable()->default(null)->change();


### PR DESCRIPTION
## Summary
- move series unique index enforcement into existing parent playlist migration
- guard category/group/series/season unique indices to add only when missing

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68bc17c5c3008321a7d8e0b639b79e80