### PR TITLE
Dispatch child playlist sync after parent completes

### DIFF
--- a/app/Listeners/SyncListener.php
+++ b/app/Listeners/SyncListener.php
@@ -40,6 +40,7 @@ class SyncListener
                     'status' => Status::Pending,
                     'processing' => false,
                 ]);
+                dispatch(new \App\Jobs\SyncPlaylistChildren($event->model));
             } elseif ($event->model->parent_id && ! $event->model->parent->processing) {
                 dispatch(new \App\Jobs\SyncPlaylistChildren($event->model->parent));
             }


### PR DESCRIPTION
## Summary
- Dispatch `SyncPlaylistChildren` when a parent playlist finishes syncing so its children begin processing

## Testing
- `php artisan test tests/Feature/PlaylistSyncTest.php --filter "dispatches child sync after parent provider sync" -v` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd70dd3508321aecfc235b092611f