### PR TITLE
Dispatch SyncCompleted event for child playlist sync

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Enums\Status;
+use App\Events\SyncCompleted;
 use App\Models\Category;
 use App\Models\Playlist;
 use App\Models\Season;
@@ -138,6 +139,7 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
                             'processing' => false,
                             'progress' => 100,
                         ]);
+                        event(new SyncCompleted($child));
                     } catch (\Throwable $e) {
                         DB::rollBack();
                         if ($copiedFile && Storage::disk('local')->exists($copiedFile)) {
@@ -147,6 +149,7 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
                             'status' => Status::Failed,
                             'processing' => false,
                         ]);
+                        event(new SyncCompleted($child));
                         throw $e;
                     }
                 }


### PR DESCRIPTION
## Summary
- dispatch `SyncCompleted` event after each child playlist sync result
- ensure event fires on both success and failure

## Testing
- `composer install --no-interaction --no-progress`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= BROADCAST_CONNECTION=log php artisan test` *(fails: Database file at path [/workspace/m3u-editor/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bcda6d1c44832185b41375efb2dd9d