### PR TITLE
Prompt for source playlist when adding to custom playlists

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace App\Filament\BulkActions;
+
+use App\Models\CustomPlaylist;
+use App\Models\Playlist;
+use Filament\Forms;
+use Filament\Forms\Components\Actions;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
+use Filament\Notifications\Notification;
+use Filament\Tables;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Provides helpers for bulk actions that need to resolve the correct
+ * source playlist when a record exists in both a parent playlist and one
+ * or more of its children.
+ *
+ * Example usage:
+ *
+ * ```php
+ * use App\Filament\BulkActions\HandlesSourcePlaylist;
+ *
+ * class ChannelResource extends Resource
+ * {
+ *     use HandlesSourcePlaylist;
+ *
+ *     public static function getTableBulkActions(): array
+ *     {
+ *         return [
+ *             self::addToCustomPlaylistBulkAction(
+ *                 \App\Models\Channel::class,
+ *                 'channels',
+ *                 'source_id',
+ *                 'channel',
+ *                 'channel'
+ *             ),
+ *         ];
+ *     }
+ * }
+ * ```
+ */
+trait HandlesSourcePlaylist
+{
+    /**
+     * Build duplicate playlist metadata for the given records.
+     *
+     * @param Collection $records   Selected records from the bulk action.
+     * @param string     $relation  Relationship name used to query playlist items (channels, series, etc.).
+     * @param string     $sourceKey Source identifier column on the related model.
+     * @return array{0: Collection, 1: bool, 2: Collection, 3: Collection} Tuple containing
+     *                                             duplicate groups, whether a source playlist is
+     *                                             needed, the source IDs of the records, and a
+     *                                             map of composite playlist/source keys to their
+     *                                             parent-child group key.
+    */
+    protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
+    {
+        $recordPlaylistIds = $records->pluck('playlist_id')->unique();
+        $recordSourceIds   = $records->pluck($sourceKey)->unique();
+
+        $parentIds = Playlist::whereIn('id', $recordPlaylistIds)
+            ->pluck('parent_id')
+            ->filter()
+            ->unique()
+            ->all();
+
+        $playlists = Playlist::where('user_id', auth()->id())
+            ->select('id', 'parent_id', 'name')
+            ->where(function ($query) use ($recordPlaylistIds, $parentIds) {
+                $query->whereIn('id', $recordPlaylistIds)
+                    ->orWhereIn('parent_id', $recordPlaylistIds);
+
+                if (! empty($parentIds)) {
+                    $query->orWhereIn('id', $parentIds);
+                }
+            })
+            ->whereHas($relation, fn ($q) => $q->whereIn($sourceKey, $recordSourceIds))
+            ->with([
+                $relation => fn ($q) => $q
+                    ->select('id', 'playlist_id', $sourceKey)
+                    ->whereIn($sourceKey, $recordSourceIds),
+            ])
+            ->get();
+
+        $playlistMap = $playlists->keyBy('id');
+
+        $groups = [];
+
+        $playlists
+            ->flatMap(fn ($playlist) => $playlist->$relation->map(fn ($item) => [
+                'source_id'   => $item->$sourceKey,
+                'playlist_id' => $playlist->id,
+            ]))
+            ->groupBy('source_id')
+            ->each(function ($group, $sourceId) use (&$groups, $playlistMap) {
+                $ids = $group->pluck('playlist_id')->unique();
+
+                if ($ids->count() <= 1) {
+                    return;
+                }
+
+                foreach ($ids as $id) {
+                    $playlist = $playlistMap[$id];
+
+                    if ($playlist->parent_id && $ids->contains($playlist->parent_id)) {
+                        $pairKey = $playlist->parent_id . '-' . $id;
+
+                        $groups[$pairKey] ??= [
+                            'parent_id'     => $playlist->parent_id,
+                            'child_id'      => $id,
+                            'playlists'     => $playlistMap
+                                ->only([$playlist->parent_id, $id])
+                                ->map->name,
+                            'source_ids'    => [],
+                            'composite_keys'=> [],
+                        ];
+
+                        $groups[$pairKey]['source_ids'][]     = $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $id . ':' . $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id . ':' . $sourceId;
+                    }
+                }
+            });
+
+        $duplicateGroups = collect($groups);
+
+        // Map composite playlist & source IDs to their parent-child pair
+        $sourceToGroup = $duplicateGroups
+            ->flatMap(fn ($group, $pairKey) => collect($group['composite_keys'])
+                ->unique()
+                ->mapWithKeys(fn ($key) => [$key => $pairKey]));
+
+        // Store the selected record details under their respective group
+        foreach ($records as $record) {
+            $sourceId  = $record->$sourceKey;
+            $composite = $record->playlist_id . ':' . $sourceId;
+
+            if (! $sourceToGroup->has($composite)) {
+                continue;
+            }
+
+            $pairKey = $sourceToGroup[$composite];
+
+            $group = $duplicateGroups[$pairKey];
+            $group['records'][$record->id] = [
+                'id'          => $record->id,
+                'title'       => $record->title ?? $record->name ?? '',
+                'source_id'   => $sourceId,
+                'playlist_id' => $record->playlist_id,
+            ];
+            $duplicateGroups[$pairKey] = $group;
+        }
+
+        $needsSourcePlaylist = $duplicateGroups->isNotEmpty();
+
+        return [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup];
+    }
+
+    /**
+     * Build form fields allowing users to choose the source playlist for
+     * duplicate parent/child groups and optionally override individual
+     * records within those groups.
+     *
+     * @param Collection      $records            Records selected in the bulk action.
+     * @param string          $relation           Relationship name used to fetch playlist items.
+     * @param string          $sourceKey          Column containing the source ID on the related model.
+     * @param string          $itemLabel          Human-readable label for the record type (channel, series, etc.).
+     * @param array|null      $sourcePlaylistData Cached metadata returned from {@see getSourcePlaylistData}.
+     *                                           Passed by reference so callers can reuse the computed data.
+     * @return array                             Array of Filament form components for inclusion in the bulk action.
+     */
+    protected static function buildSourcePlaylistForm(
+        Collection $records,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        ?array &$sourcePlaylistData = null
+    ): array {
+        if ($sourcePlaylistData === null) {
+            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+        }
+
+        [$duplicateGroups, $needsSourcePlaylist] = $sourcePlaylistData;
+
+        if (! $needsSourcePlaylist) {
+            return [];
+        }
+
+        $fields = [];
+
+        foreach ($duplicateGroups as $pairKey => $group) {
+            $parentName = $group['playlists'][$group['parent_id']];
+            $childName  = $group['playlists'][$group['child_id']];
+
+            $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
+                ->schema([
+                    Forms\Components\Select::make("source_playlists.{$pairKey}")
+                        ->label('Use items from:')
+                        ->options($group['playlists']->toArray())
+                        ->required()
+                        ->searchable(),
+                    Actions::make([
+                        Action::make("view_affected_{$pairKey}")
+                            ->label('View affected items')
+                            ->modalHeading("Items in {$parentName} ↔ {$childName}")
+                            ->statePath("source_playlists_items.{$pairKey}")
+                            ->form(
+                                collect($group['records'] ?? [])->map(fn ($record) =>
+                                    Forms\Components\Select::make((string) $record['id'])
+                                        ->label($record['title'])
+                                        ->options($group['playlists']->toArray())
+                                        ->placeholder('Use group selection')
+                                        ->searchable()
+                                )->toArray()
+                            ),
+                    ]),
+                ]);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Resolve each selected record to the appropriate source playlist entry
+     * based on the user's selections.
+     *
+     * Performs validation to ensure every duplicate parent/child group has a
+     * source playlist chosen, and replaces records with their counterpart from
+     * the selected source playlist.
+     *
+     * @param Collection $records           Records originally selected in the bulk action.
+     * @param array      $data              Form data submitted by the user.
+     * @param string     $relation          Relationship name used to fetch playlist items.
+     * @param string     $sourceKey         Source identifier column on the related model.
+     * @param string     $modelClass        Fully qualified model class name for the records.
+     * @param array|null $sourcePlaylistData Cached metadata from {@see getSourcePlaylistData}.
+     *                                       Passed by reference to avoid recomputation.
+     * @return Collection                    Collection of records mapped to their chosen source playlist.
+     * @throws ValidationException           If any duplicate group lacks a source selection.
+     */
+    protected static function mapRecordsToSourcePlaylist(
+        Collection $records,
+        array $data,
+        string $relation,
+        string $sourceKey,
+        string $modelClass,
+        ?array $sourcePlaylistData = null
+    ): Collection {
+        if ($sourcePlaylistData === null) {
+            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+        }
+
+        [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
+
+        if ($needsSourcePlaylist) {
+            $selected     = collect($data['source_playlists'] ?? []);
+            $itemSelected = collect($data['source_playlists_items'] ?? []);
+
+            foreach ($duplicateGroups as $pairKey => $group) {
+                $bulk   = $selected[$pairKey] ?? null;
+                $items  = collect($itemSelected[$pairKey] ?? [])->filter();
+                $count  = count($group['records'] ?? []);
+
+                if (! $bulk && $items->count() !== $count) {
+                    throw ValidationException::withMessages([
+                        'source_playlists' => 'Please select a source playlist for each duplicated group.',
+                    ]);
+                }
+            }
+
+            $playlistIds = $selected->filter()->values();
+            $playlistIds = $playlistIds->merge(
+                $itemSelected->flatMap(fn ($items) => collect($items)->filter()->values())
+            )->unique();
+
+            $sourceMaps = $modelClass::query()
+                ->whereIn('playlist_id', $playlistIds)
+                ->whereIn($sourceKey, $recordSourceIds)
+                ->select('id', 'playlist_id', $sourceKey)
+                ->get()
+                ->groupBy('playlist_id')
+                ->map->keyBy($sourceKey);
+
+            $records = $records->map(function ($record) use ($selected, $itemSelected, $sourceMaps, $sourceToGroup, $sourceKey) {
+                $sourceId  = $record->$sourceKey;
+                $composite = $record->playlist_id . ':' . $sourceId;
+
+                if ($sourceToGroup->has($composite)) {
+                    $pairKey    = $sourceToGroup[$composite];
+                    $override   = $itemSelected[$pairKey][$record->id] ?? null;
+                    $playlistId = $override ?: ($selected[$pairKey] ?? null);
+
+                    return $playlistId && isset($sourceMaps[$playlistId][$sourceId])
+                        ? $sourceMaps[$playlistId][$sourceId]
+                        : $record;
+                }
+
+                return $record;
+            });
+        }
+
+        return $records;
+    }
+
+    /**
+     * Construct a Filament bulk action that adds the selected records to a
+     * custom playlist, including optional source playlist disambiguation.
+     *
+     * @param string $modelClass    Fully qualified model class for the records.
+     * @param string $relation      Relationship name used by the custom playlist (channels, series, vods).
+     * @param string $sourceKey     Column containing the source ID on the related model.
+     * @param string $itemLabel     Human-readable label for the record type.
+     * @param string $tagType       Tag type used when assigning categories/groups.
+     * @param string $categoryLabel Label displayed for the category select.
+     * @return Tables\Actions\BulkAction Configured bulk action ready to attach to a Filament table.
+     */
+    protected static function buildAddToCustomPlaylistAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group'
+    ): Tables\Actions\BulkAction {
+        $sourcePlaylistData = null;
+
+        return Tables\Actions\BulkAction::make('add')
+            ->label('Add to Custom Playlist')
+            ->form(function (Collection $records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData): array {
+                $form = [
+                    Forms\Components\Select::make('playlist')
+                        ->required()
+                        ->live()
+                        ->label('Custom Playlist')
+                        ->helperText("Select the custom playlist you would like to add the selected {$itemLabel} to.")
+                        ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
+                        ->afterStateUpdated(fn (Set $set, $state) => $state ? $set('category', null) : null)
+                        ->searchable(),
+                    Forms\Components\Select::make('category')
+                        ->label($categoryLabel)
+                        ->disabled(fn (Get $get) => ! $get('playlist'))
+                        ->helperText(fn (Get $get) => ! $get('playlist')
+                            ? 'Select a custom playlist first.'
+                            : 'Select the ' . ($categoryLabel === 'Custom Group' ? 'group' : 'category') .
+                                ' you would like to assign to the selected ' . $itemLabel . ' to.')
+                        ->options(function ($get) use ($tagType) {
+                            $customList = CustomPlaylist::find($get('playlist'));
+                            return $customList ? $customList->tags()
+                                ->where('type', $customList->uuid . $tagType)
+                                ->get()
+                                ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
+                                ->toArray() : [];
+                        })
+                        ->searchable(),
+                ];
+
+                $form = array_merge(
+                    $form,
+                    self::buildSourcePlaylistForm($records, $relation, $sourceKey, $itemLabel, $sourcePlaylistData)
+                );
+
+                return $form;
+            })
+            ->action(function (Collection $records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData): void {
+                $records = self::mapRecordsToSourcePlaylist($records, $data, $relation, $sourceKey, $modelClass, $sourcePlaylistData);
+
+                $playlist = CustomPlaylist::findOrFail($data['playlist']);
+                $playlist->$relation()->syncWithoutDetaching($records->pluck('id'));
+                if ($data['category']) {
+                    $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
+                }
+            })
+            ->after(function () use ($itemLabel) {
+                Notification::make()
+                    ->success()
+                    ->title(ucfirst($itemLabel) . ' added to custom playlist')
+                    ->body("The selected {$itemLabel} have been added to the chosen custom playlist.")
+                    ->send();
+            })
+            ->deselectRecordsAfterCompletion()
+            ->requiresConfirmation()
+            ->icon('heroicon-o-play')
+            ->modalIcon('heroicon-o-play')
+            ->modalDescription("Add the selected {$itemLabel} to the chosen custom playlist.")
+            ->modalSubmitActionLabel('Add now');
+    }
+
+    public static function addToCustomPlaylistBulkAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group'
+    ): Tables\Actions\BulkAction {
+        return self::buildAddToCustomPlaylistAction($modelClass, $relation, $sourceKey, $itemLabel, $tagType, $categoryLabel);
+    }
+}

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -14,6 +14,7 @@ use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -30,9 +31,11 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class ChannelResource extends Resource
 {
+    use HandlesSourcePlaylist;
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -359,55 +362,8 @@ class ChannelResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Channel::class, 'channels', 'source_id', 'channel(s)', '')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -115,6 +115,11 @@ class ChannelsRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -123,7 +128,7 @@ class ChannelsRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent'])
                     ->withCount(['failovers'])
                     ->where('is_vod', false); // Only show live channels
             })

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -105,6 +105,11 @@ class SeriesRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 6, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -112,6 +117,7 @@ class SeriesRelationManager extends RelationManager
             ->filtersTriggerAction(function ($action) {
                 return $action->button()->label('Filters');
             })
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('playlist.parent'))
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
             ->columns($defaultColumns)

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
@@ -115,6 +115,11 @@ class VodRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -123,7 +128,7 @@ class VodRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent'])
                     ->withCount(['failovers'])
                     ->where('is_vod', true); // Only show VOD content
             })

--- a/app/Filament/Resources/SeriesResource.php
+++ b/app/Filament/Resources/SeriesResource.php
@@ -6,9 +6,9 @@ use App\Facades\LogoFacade;
 use App\Filament\Resources\SeriesResource\Pages;
 use App\Filament\Resources\SeriesResource\RelationManagers;
 use App\Models\Category;
-use App\Models\CustomPlaylist;
 use App\Models\Playlist;
 use App\Models\Series;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Rules\CheckIfUrlOrLocalPath;
 use App\Services\XtreamService;
 use Filament\Forms;
@@ -25,9 +25,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Validation\ValidationException;
 
 class SeriesResource extends Resource
 {
+    use HandlesSourcePlaylist;
     protected static ?string $model = Series::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -255,55 +257,8 @@ class SeriesResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected series to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Category')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the category you would like to assign to the selected series to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid . '-category')
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->series()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Series added to custom playlist')
-                            ->body('The selected series have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected series to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Series::class, 'series', 'source_series_id', 'series', '-category', 'Custom Category')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move Series to Category')
                     ->form([

--- a/app/Filament/Resources/VodResource.php
+++ b/app/Filament/Resources/VodResource.php
@@ -14,6 +14,7 @@ use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Rules\CheckIfUrlOrLocalPath;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -31,9 +32,11 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class VodResource extends Resource
 {
+    use HandlesSourcePlaylist;
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -414,55 +417,8 @@ class VodResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Channel::class, 'channels', 'source_id', 'channel(s)', '')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([

--- a/tests/Feature/SeriesSourcePlaylistSelectorVisibilityTest.php
+++ b/tests/Feature/SeriesSourcePlaylistSelectorVisibilityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\Series;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Filament\Forms;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function makeSeriesFormHandler() {
+    return new class {
+        use HandlesSourcePlaylist {
+            buildSourcePlaylistForm as public;
+        }
+    };
+}
+
+it('hides the source playlist selector when no duplicates exist', function () {
+    $handler = makeSeriesFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $series = Series::factory()->for($user)->create([
+        'playlist_id'      => $playlist->id,
+        'source_series_id' => 1,
+        'name'             => 'Series 1',
+    ]);
+
+    $records = collect([$series]);
+
+    $form = $handler::buildSourcePlaylistForm($records, 'series', 'source_series_id', 'series');
+
+    expect($form)->toBeEmpty();
+});
+
+it('renders one required selector for a single parent-child duplicate pair', function () {
+    $handler = makeSeriesFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    Series::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_series_id' => 1, 'name' => 'A']);
+    $childSeries = Series::factory()->for($user)->create(['playlist_id' => $child->id, 'source_series_id' => 1, 'name' => 'A']);
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childSeries]), 'series', 'source_series_id', 'series');
+
+    expect($form)->toHaveCount(1);
+
+    $select = $form[0]->getChildComponents()[0];
+
+    expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+    expect($select->isRequired())->toBeTrue();
+});
+
+it('renders one selector per duplicated parent-child group', function () {
+    $handler = makeSeriesFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    Series::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_series_id' => 1, 'name' => 'A']);
+    $childSeriesA = Series::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_series_id' => 1, 'name' => 'A']);
+    $childSeriesB = Series::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_series_id' => 1, 'name' => 'A']);
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childSeriesA, $childSeriesB]), 'series', 'source_series_id', 'series');
+
+    expect($form)->toHaveCount(2);
+
+    foreach ($form as $fieldset) {
+        $select = $fieldset->getChildComponents()[0];
+        expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+        expect($select->isRequired())->toBeTrue();
+    }
+});
+
+

--- a/tests/Feature/SourcePlaylistOverrideTest.php
+++ b/tests/Feature/SourcePlaylistOverrideTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+function makeHandler() {
+    return new class {
+        use HandlesSourcePlaylist {
+            getSourcePlaylistData as public;
+            mapRecordsToSourcePlaylist as public;
+        }
+    };
+}
+
+it('applies bulk source selection when no overrides', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel1 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel1  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentChannel2 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childChannel2  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = collect([$childChannel1, $childChannel2]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+    $pairKey = $groups->keys()->first();
+
+    $mapped = $handler::mapRecordsToSourcePlaylist(
+        $records,
+        ['source_playlists' => [$pairKey => $parent->id]],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+
+    expect($mapped->pluck('id')->all())->toEqual([$parentChannel1->id, $parentChannel2->id]);
+});
+
+it('applies per-item overrides', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel1 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel1  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentChannel2 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childChannel2  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = collect([$childChannel1, $childChannel2]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+    $pairKey = $groups->keys()->first();
+
+    $mapped = $handler::mapRecordsToSourcePlaylist(
+        $records,
+        [
+            'source_playlists' => [$pairKey => $parent->id],
+            'source_playlists_items' => [
+                $pairKey => [
+                    $childChannel2->id => $child->id,
+                ],
+            ],
+        ],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+
+    expect($mapped->pluck('id')->all())->toEqual([$parentChannel1->id, $childChannel2->id]);
+});
+
+it('maps records to correct groups when channel exists in multiple child playlists', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childAChannel = Channel::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_id' => 1, 'title' => 'A']);
+    $childBChannel = Channel::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_id' => 1, 'title' => 'A']);
+
+    $records = collect([$childAChannel, $childBChannel]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+
+    $mapped = $handler::mapRecordsToSourcePlaylist(
+        $records,
+        [
+            'source_playlists' => [
+                $parent->id . '-' . $childA->id => $parent->id,
+                $parent->id . '-' . $childB->id => $childB->id,
+            ],
+        ],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+
+    expect($mapped->pluck('id')->all())->toEqual([$parentChannel->id, $childBChannel->id]);
+});
+
+it('fails validation when selections are missing', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel1 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel1  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentChannel2 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childChannel2  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = collect([$childChannel1, $childChannel2]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+    $pairKey = $groups->keys()->first();
+
+    $handler::mapRecordsToSourcePlaylist(
+        $records,
+        [
+            'source_playlists_items' => [
+                $pairKey => [
+                    $childChannel1->id => $parent->id,
+                ],
+            ],
+        ],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+})->throws(ValidationException::class);

--- a/tests/Feature/SourcePlaylistSelectorVisibilityTest.php
+++ b/tests/Feature/SourcePlaylistSelectorVisibilityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Filament\Forms;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function makeFormHandler() {
+    return new class {
+        use HandlesSourcePlaylist {
+            buildSourcePlaylistForm as public;
+        }
+    };
+}
+
+it('hides the source playlist selector when no duplicates exist', function () {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $channel = Channel::factory()->for($user)->create([
+        'playlist_id' => $playlist->id,
+        'source_id'   => 1,
+        'title'       => 'Channel 1',
+    ]);
+
+    $records = collect([$channel]);
+
+    $form = $handler::buildSourcePlaylistForm($records, 'channels', 'source_id', 'channel');
+
+    expect($form)->toBeEmpty();
+});
+
+it('renders one required selector for a single parent-child duplicate pair', function () {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childChannel]), 'channels', 'source_id', 'channel');
+
+    expect($form)->toHaveCount(1);
+
+    $select = $form[0]->getChildComponents()[0];
+
+    expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+    expect($select->isRequired())->toBeTrue();
+});
+
+it('renders one selector per duplicated parent-child group', function () {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannelA = Channel::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannelB = Channel::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_id' => 1, 'title' => 'A']);
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childChannelA, $childChannelB]), 'channels', 'source_id', 'channel');
+
+    expect($form)->toHaveCount(2);
+
+    foreach ($form as $fieldset) {
+        $select = $fieldset->getChildComponents()[0];
+        expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+        expect($select->isRequired())->toBeTrue();
+    }
+});
+
+

--- a/tests/Feature/VodSourcePlaylistSelectorVisibilityTest.php
+++ b/tests/Feature/VodSourcePlaylistSelectorVisibilityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Filament\Forms;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function makeVodFormHandler() {
+    return new class {
+        use HandlesSourcePlaylist {
+            buildSourcePlaylistForm as public;
+        }
+    };
+}
+
+it('hides the source playlist selector when no duplicates exist', function () {
+    $handler = makeVodFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $channel = Channel::factory()->for($user)->create([
+        'playlist_id' => $playlist->id,
+        'source_id'   => 1,
+        'title'       => 'Channel 1',
+        'is_vod'      => true,
+    ]);
+
+    $records = collect([$channel]);
+
+    $form = $handler::buildSourcePlaylistForm($records, 'channels', 'source_id', 'channel');
+
+    expect($form)->toBeEmpty();
+});
+
+it('renders one required selector for a single parent-child duplicate pair', function () {
+    $handler = makeVodFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $childChannel = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childChannel]), 'channels', 'source_id', 'channel');
+
+    expect($form)->toHaveCount(1);
+
+    $select = $form[0]->getChildComponents()[0];
+
+    expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+    expect($select->isRequired())->toBeTrue();
+});
+
+it('renders one selector per duplicated parent-child group', function () {
+    $handler = makeVodFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $childChannelA = Channel::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $childChannelB = Channel::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childChannelA, $childChannelB]), 'channels', 'source_id', 'channel');
+
+    expect($form)->toHaveCount(2);
+
+    foreach ($form as $fieldset) {
+        $select = $fieldset->getChildComponents()[0];
+        expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+        expect($select->isRequired())->toBeTrue();
+    }
+});
+
+


### PR DESCRIPTION
## Summary
- make source playlist selection required when duplicate parent–child groups surface during bulk actions
- verify source playlist selectors show only for duplicated parent/child sets and are required when present
- dedupe parent playlist IDs before duplicate detection to avoid redundant lookups
- reuse source-to-group map from duplicate detection to avoid recalculating during record mapping
- limit mapped source playlist records to `id`, `playlist_id`, and source key columns to cut memory overhead
- cover selector visibility for series and VOD bulk additions

## Testing
- `composer install --no-interaction`
- `BROADCAST_DRIVER=log PUSHER_APP_ID=dummy PUSHER_APP_KEY=dummy PUSHER_APP_SECRET=dummy PUSHER_APP_CLUSTER=mt1 DB_CONNECTION=sqlite DB_DATABASE=database/database.sqlite ./vendor/bin/pest` *(failures: SourcePlaylistSelectorVisibilityTest, VodSourcePlaylistSelectorVisibilityTest, SourcePlaylistOverrideTest, SourceIndexesTest, SharedStreamService tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bcea88474c8321b04398f7e2aeaf50