### PR TITLE
Ensure child playlists are detached when parent deleted

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -94,6 +94,7 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
             Log::warning("SyncPlaylistChildren: Parent playlist {$this->playlist->id} not found, clearing queued flag and aborting child sync.");
             Cache::forget("playlist-sync:{$this->playlist->id}");
             Cache::forget("playlist-sync:{$this->playlist->id}:queued");
+            Cache::lock("playlist-sync-children:{$this->playlist->id}")->forceRelease();
 
             return;
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -170,6 +170,9 @@ class AppServiceProvider extends ServiceProvider
                 return $playlist;
             });
             Playlist::deleting(function (Playlist $playlist) {
+                // Detach any child playlists so they become standalone playlists
+                $playlist->children()->update(['parent_id' => null]);
+
                 Storage::disk('local')->deleteDirectory($playlist->folder_path);
                 if ($playlist->uploads && Storage::disk('local')->exists($playlist->uploads)) {
                     Storage::disk('local')->delete($playlist->uploads);

--- a/tests/Feature/ParentPlaylistDeletionTest.php
+++ b/tests/Feature/ParentPlaylistDeletionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+it('converts child playlists to normal playlists when parent is deleted', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childOne = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childTwo = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parent->delete();
+
+    $childOne->refresh();
+    $childTwo->refresh();
+
+    expect($childOne->parent_id)->toBeNull();
+    expect($childTwo->parent_id)->toBeNull();
+    expect(Playlist::find($childOne->id))->not->toBeNull();
+    expect(Playlist::find($childTwo->id))->not->toBeNull();
+});

--- a/tests/Feature/SyncPlaylistChildrenLockTest.php
+++ b/tests/Feature/SyncPlaylistChildrenLockTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Jobs\SyncPlaylistChildren;
+use App\Models\Playlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+
+uses(RefreshDatabase::class);
+
+it('releases lock when parent playlist is missing', function () {
+    $playlist = Playlist::factory()->create();
+
+    Config::set('cache.default', 'database');
+
+    $lockName = "playlist-sync-children:{$playlist->id}";
+    Cache::lock($lockName)->get();
+
+    $job = new SyncPlaylistChildren($playlist);
+    $playlist->delete();
+
+    $job->handle();
+
+    expect(Cache::lock($lockName)->get())->toBeTrue();
+    Cache::lock($lockName)->forceRelease();
+});


### PR DESCRIPTION
## Summary
- detach child playlists by nulling their parent_id during parent deletion
- force-release child sync locks when parent playlist no longer exists
- add regression tests for child detachment and lock release

## Testing
- `php artisan test tests/Feature/ParentPlaylistDeletionTest.php tests/Feature/SyncPlaylistChildrenLockTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd509047488321bbb6f5577eea53d1