### PR TITLE
Add failover preservation test for playlist delta sync

### DIFF
--- a/tests/Feature/PlaylistDeltaSyncTest.php
+++ b/tests/Feature/PlaylistDeltaSyncTest.php
@@ -3,9 +3,12 @@
 use App\Jobs\DuplicatePlaylist;
 use App\Jobs\SyncPlaylistChildren;
 use App\Models\Channel;
+use App\Models\ChannelFailover;
 use App\Models\Group;
 use App\Models\Category;
 use App\Models\Series;
+use App\Models\Season;
+use App\Models\Episode;
 use App\Models\Playlist;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
@@ -73,10 +76,31 @@ function createSyncedPair(): array {
         'source_series_id' => null,
     ]);
 
+    $season = Season::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'category_id' => $catA->id,
+        'series_id' => $series1->id,
+        'name' => 'Season1',
+        'season_number' => 1,
+        'source_season_id' => null,
+    ]);
+
+    $episode = Episode::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'series_id' => $series1->id,
+        'season_id' => $season->id,
+        'title' => 'Ep1',
+        'episode_num' => 1,
+        'season' => 1,
+        'source_episode_id' => null,
+    ]);
+
     (new DuplicatePlaylist($playlist, withSync: true))->handle();
     $child = Playlist::where('parent_id', $playlist->id)->first();
 
-    return [$playlist, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2];
+    return [$playlist, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode];
 }
 
 it('renames a channel without touching others', function () {
@@ -121,6 +145,49 @@ it('deletes a channel without touching others', function () {
     expect($childCh2->updated_at)->toEqual($oldUpdated);
 });
 
+it('keeps child failover reference after a channel update', function () {
+    $playlist = Playlist::factory()->create();
+    $group = Group::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'name' => 'G',
+        'name_internal' => 'g',
+    ]);
+    $chan1 = Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'group_id' => $group->id,
+        'name' => 'One',
+        'source_id' => null,
+    ]);
+    $chan2 = Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'group_id' => $group->id,
+        'name' => 'Two',
+        'source_id' => null,
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $playlist->user_id,
+        'channel_id' => $chan1->id,
+        'channel_failover_id' => $chan2->id,
+        'sort' => 0,
+        'metadata' => [],
+    ]);
+
+    (new DuplicatePlaylist($playlist, withSync: true))->handle();
+    $child = Playlist::where('parent_id', $playlist->id)->first();
+
+    $chan1->update(['name' => 'Uno']);
+    (new SyncPlaylistChildren($playlist, ['channels' => ['ch-' . $chan1->id]]))->handle();
+
+    $childChan1 = $child->channels()->where('source_id', 'ch-' . $chan1->id)->first();
+    $childChan2 = $child->channels()->where('source_id', 'ch-' . $chan2->id)->first();
+
+    expect($childChan1->failovers()->first()->channel_failover_id)->toBe($childChan2->id);
+});
+
 it('renames a category without touching others', function () {
     [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB] = createSyncedPair();
 
@@ -147,6 +214,34 @@ it('renames a series without touching others', function () {
     expect($child->series()->where('source_series_id', 'series-' . $series1->id)->first()->name)->toBe('S1');
     $childSeries2->refresh();
     expect($childSeries2->updated_at)->toEqual($oldUpdated);
+});
+
+it('renames a season without touching its episodes', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode] = createSyncedPair();
+
+    $childEpisode = $child->episodes()->where('source_episode_id', 'ep-' . $episode->id)->first();
+    $oldUpdated = $childEpisode->updated_at;
+
+    $season->update(['name' => 'Season Uno']);
+    (new SyncPlaylistChildren($parent, ['seasons' => ['season-' . $season->id]]))->handle();
+
+    expect($child->seasons()->where('source_season_id', 'season-' . $season->id)->first()->name)->toBe('Season Uno');
+    $childEpisode->refresh();
+    expect($childEpisode->updated_at)->toEqual($oldUpdated);
+});
+
+it('renames an episode without touching its season', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode] = createSyncedPair();
+
+    $childSeason = $child->seasons()->where('source_season_id', 'season-' . $season->id)->first();
+    $oldUpdated = $childSeason->updated_at;
+
+    $episode->update(['title' => 'Episode Uno']);
+    (new SyncPlaylistChildren($parent, ['episodes' => ['ep-' . $episode->id]]))->handle();
+
+    expect($child->episodes()->where('source_episode_id', 'ep-' . $episode->id)->first()->title)->toBe('Episode Uno');
+    $childSeason->refresh();
+    expect($childSeason->updated_at)->toEqual($oldUpdated);
 });
 
 it('coalesces multiple channel renames into one job', function () {


### PR DESCRIPTION
## Summary
- extend test fixture to include a season and episode
- verify season and episode renames only update corresponding child records

## Testing
- `BROADCAST_CONNECTION=log php artisan test` *(fails: file_get_contents(/workspace/m3u-editor/.env)...)*


------
https://chatgpt.com/codex/tasks/task_e_68bd528495b08321b89495537c60c6e6