### PR TITLE
Chain child imports and mapping before syncing children

### DIFF
--- a/app/Jobs/MapPlaylistChannelsToEpg.php
+++ b/app/Jobs/MapPlaylistChannelsToEpg.php
@@ -241,7 +241,7 @@ class MapPlaylistChannelsToEpg implements ShouldQueue
             });
 
             // Last job in the batch
-            $jobs[] = new MapEpgToChannelsComplete($epg, $batchCount, $channelCount, $mappedCount, $batchNo, $start);
+            $jobs[] = new MapEpgToChannelsComplete($epg, $playlist, $batchCount, $channelCount, $mappedCount, $batchNo, $start);
 
             // Dispatch the batch
             Bus::chain($jobs)


### PR DESCRIPTION
## Summary
- Chain child playlist imports, parent EPG mapping, and final child sync in `SyncListener`
- Guard chained workflow with parent-level lock and reuse existing `SyncPlaylistChildren` job
- Fan out standalone EPG mappings to child playlists by debouncing `SyncPlaylistChildren`

## Testing
- `composer install`
- `vendor/bin/pest` *(fails: Pusher constructor missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5bf1245883219bee5769bb2bcd37