### PR TITLE
feat: add group-based channel drilldown for playlist actions

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -60,7 +60,7 @@ trait HandlesSourcePlaylist
     protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
     {
         $recordPlaylistIds = $records->pluck('playlist_id')->unique();
-        $recordSourceIds   = $records->pluck($sourceKey)->unique();
+        $recordSourceIds   = $records->pluck($sourceKey)->filter()->unique();
 
         $parentIds = Playlist::whereIn('id', $recordPlaylistIds)
             ->pluck('parent_id')
@@ -178,10 +178,50 @@ trait HandlesSourcePlaylist
         string $relation,
         string $sourceKey,
         string $itemLabel,
-        ?array &$sourcePlaylistData = null
+        ?array &$sourcePlaylistData = null,
+        ?Collection $grouped = null,
+        bool $allowDrilldown = true
     ): array {
         if ($sourcePlaylistData === null) {
-            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+            if ($grouped) {
+                $allDuplicateGroups = collect();
+                $needsSourcePlaylist = false;
+                $recordSourceIds = collect();
+                $sourceToGroup = collect();
+
+                foreach ($grouped as $groupEntry) {
+                    $groupModel = $groupEntry['group'];
+                    $channels   = $groupEntry['channels'];
+                    [
+                        $duplicateGroups,
+                        $needs,
+                        $sourceIds,
+                        $map,
+                    ] = self::getSourcePlaylistData($channels, $relation, $sourceKey);
+
+                    if ($needs) {
+                        $needsSourcePlaylist = true;
+                    }
+
+                    foreach ($duplicateGroups as $pairKey => $data) {
+                        $allDuplicateGroups[$groupModel->id . '|' . $pairKey] = $data;
+                    }
+
+                    $recordSourceIds = $recordSourceIds->merge($sourceIds);
+                    $sourceToGroup   = $sourceToGroup->merge(
+                        $map->map(fn ($pairKey) => $groupModel->id . '|' . $pairKey)
+                    );
+                }
+
+                $sourcePlaylistData = [
+                    $allDuplicateGroups,
+                    $needsSourcePlaylist,
+                    $recordSourceIds->unique(),
+                    $sourceToGroup,
+                ];
+            } else {
+                $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+            }
         }
 
         [$duplicateGroups, $needsSourcePlaylist] = $sourcePlaylistData;
@@ -190,38 +230,120 @@ trait HandlesSourcePlaylist
             return [];
         }
 
+        // When grouped records are provided, organise duplicate groups by parent group
+        if ($grouped) {
+            $byGroup = [];
+            foreach ($duplicateGroups as $key => $group) {
+                [$groupId, $pairKey] = explode('|', $key, 2);
+                $byGroup[$groupId][$pairKey] = $group;
+            }
+
+            $fields = [];
+            foreach ($grouped as $groupEntry) {
+                $groupModel = $groupEntry['group'];
+                $groupId    = (string) $groupModel->id;
+                if (! isset($byGroup[$groupId])) {
+                    continue;
+                }
+
+                $fields[] = Forms\Components\Fieldset::make($groupModel->name)
+                    ->schema(collect($byGroup[$groupId])->map(function ($group, $pairKey) use ($groupId, $itemLabel, $allowDrilldown) {
+                        $globalKey = $groupId . '|' . $pairKey;
+                        $parentName = $group['playlists'][$group['parent_id']];
+                        $childName  = $group['playlists'][$group['child_id']];
+
+                        $schema = [
+                            Forms\Components\Select::make("source_playlists.{$globalKey}")
+                                ->label('Use items from:')
+                                ->options($group['playlists']->toArray())
+                                ->required()
+                                ->searchable(),
+                        ];
+
+                        if ($allowDrilldown) {
+                            $schema[] = Actions::make([
+                                Action::make("view_channels_{$globalKey}")
+                                    ->label('View channels')
+                                    ->modalHeading("Channels in {$parentName} ↔ {$childName}")
+                                    ->statePath("source_playlists_items.{$globalKey}")
+                                    ->steps(self::buildChannelSteps(collect($group['records'] ?? []), $group['playlists'])),
+                            ]);
+                        }
+
+                        return Forms\Components\Fieldset::make("{$parentName} ↔ {$childName}")
+                            ->schema($schema);
+                    })->toArray());
+            }
+
+            return $fields;
+        }
+
+        // Default behaviour for ungrouped records
         $fields = [];
 
         foreach ($duplicateGroups as $pairKey => $group) {
             $parentName = $group['playlists'][$group['parent_id']];
             $childName  = $group['playlists'][$group['child_id']];
 
-            $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
-                ->schema([
-                    Forms\Components\Select::make("source_playlists.{$pairKey}")
-                        ->label('Use items from:')
-                        ->options($group['playlists']->toArray())
-                        ->required()
-                        ->searchable(),
-                    Actions::make([
-                        Action::make("view_affected_{$pairKey}")
-                            ->label('View affected items')
-                            ->modalHeading("Items in {$parentName} ↔ {$childName}")
-                            ->statePath("source_playlists_items.{$pairKey}")
-                            ->form(
-                                collect($group['records'] ?? [])->map(fn ($record) =>
-                                    Forms\Components\Select::make((string) $record['id'])
-                                        ->label($record['title'])
-                                        ->options($group['playlists']->toArray())
-                                        ->placeholder('Use group selection')
-                                        ->searchable()
-                                )->toArray()
-                            ),
-                    ]),
+            $schema = [
+                Forms\Components\Select::make("source_playlists.{$pairKey}")
+                    ->label('Use items from:')
+                    ->options($group['playlists']->toArray())
+                    ->required()
+                    ->searchable(),
+            ];
+
+            if ($allowDrilldown) {
+                $schema[] = Actions::make([
+                    Action::make("view_affected_{$pairKey}")
+                        ->label('View affected items')
+                        ->modalHeading("Items in {$parentName} ↔ {$childName}")
+                        ->statePath("source_playlists_items.{$pairKey}")
+                        ->steps(self::buildChannelSteps(collect($group['records'] ?? []), $group['playlists'])),
                 ]);
+            }
+
+            $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
+                ->schema($schema);
         }
 
         return $fields;
+    }
+
+    /**
+     * Build wizard steps to paginate channel overrides.
+     */
+    protected static function buildChannelSteps(Collection $records, Collection $playlists): array
+    {
+        $chunks = $records->chunk(10);
+        $steps = [];
+        foreach ($chunks as $index => $chunk) {
+            $steps[] = Forms\Components\Wizard\Step::make('Page ' . ($index + 1))
+                ->schema(
+                    $chunk->map(fn ($record) =>
+                        Forms\Components\Select::make((string) $record['id'])
+                            ->label($record['title'])
+                            ->options($playlists->toArray())
+                            ->placeholder('Use group selection')
+                            ->searchable()
+                    )->toArray()
+                );
+        }
+
+        return $steps;
+    }
+
+    /**
+     * Flatten grouped records into a single collection of models.
+     */
+    protected static function flattenRecords(Collection $records): Collection
+    {
+        $first = $records->first();
+        if ($first instanceof \Illuminate\Database\Eloquent\Model) {
+            return $records;
+        }
+
+        return $records->flatMap(fn ($group) => $group['channels']);
     }
 
     /**
@@ -324,13 +446,25 @@ trait HandlesSourcePlaylist
         string $sourceKey,
         string $itemLabel,
         string $tagType,
-        string $categoryLabel = 'Custom Group'
-    ): Tables\Actions\BulkAction {
+        string $categoryLabel = 'Custom Group',
+        ?callable $recordsResolver = null,
+        bool $allowDrilldown = true,
+        string $actionClass = \Filament\Tables\Actions\BulkAction::class,
+        bool $isBulk = true
+    ): \Filament\Actions\Action {
         $sourcePlaylistData = null;
 
-        return Tables\Actions\BulkAction::make('add')
+        /** @var \Filament\Actions\Action $action */
+        $action = $actionClass::make('add')
             ->label('Add to Custom Playlist')
-            ->form(function (Collection $records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData): array {
+            ->form(function ($records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData, $recordsResolver, $isBulk, $allowDrilldown): array {
+                $records = $isBulk ? $records : collect([$records]);
+                if ($recordsResolver) {
+                    $records = $recordsResolver($records);
+                }
+
+                $flatRecords = self::flattenRecords($records);
+
                 $form = [
                     Forms\Components\Select::make('playlist')
                         ->required()
@@ -360,13 +494,20 @@ trait HandlesSourcePlaylist
 
                 $form = array_merge(
                     $form,
-                    self::buildSourcePlaylistForm($records, $relation, $sourceKey, $itemLabel, $sourcePlaylistData)
+                    self::buildSourcePlaylistForm($flatRecords, $relation, $sourceKey, $itemLabel, $sourcePlaylistData, $records, $allowDrilldown)
                 );
 
                 return $form;
             })
-            ->action(function (Collection $records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData): void {
-                $records = self::mapRecordsToSourcePlaylist($records, $data, $relation, $sourceKey, $modelClass, $sourcePlaylistData);
+            ->action(function ($records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData, $recordsResolver, $isBulk): void {
+                $records = $isBulk ? $records : collect([$records]);
+                if ($recordsResolver) {
+                    $records = $recordsResolver($records);
+                }
+
+                $flatRecords = self::flattenRecords($records);
+
+                $records = self::mapRecordsToSourcePlaylist($flatRecords, $data, $relation, $sourceKey, $modelClass, $sourcePlaylistData);
 
                 $playlist = CustomPlaylist::findOrFail($data['playlist']);
                 $playlist->$relation()->syncWithoutDetaching($records->pluck('id'));
@@ -381,12 +522,17 @@ trait HandlesSourcePlaylist
                     ->body("The selected {$itemLabel} have been added to the chosen custom playlist.")
                     ->send();
             })
-            ->deselectRecordsAfterCompletion()
             ->requiresConfirmation()
             ->icon('heroicon-o-play')
             ->modalIcon('heroicon-o-play')
             ->modalDescription("Add the selected {$itemLabel} to the chosen custom playlist.")
             ->modalSubmitActionLabel('Add now');
+
+        if ($isBulk && method_exists($action, 'deselectRecordsAfterCompletion')) {
+            $action->deselectRecordsAfterCompletion();
+        }
+
+        return $action;
     }
 
     public static function addToCustomPlaylistBulkAction(
@@ -395,8 +541,46 @@ trait HandlesSourcePlaylist
         string $sourceKey,
         string $itemLabel,
         string $tagType,
-        string $categoryLabel = 'Custom Group'
+        string $categoryLabel = 'Custom Group',
+        ?callable $recordsResolver = null,
+        bool $allowDrilldown = true
     ): Tables\Actions\BulkAction {
-        return self::buildAddToCustomPlaylistAction($modelClass, $relation, $sourceKey, $itemLabel, $tagType, $categoryLabel);
+        return self::buildAddToCustomPlaylistAction(
+            $modelClass,
+            $relation,
+            $sourceKey,
+            $itemLabel,
+            $tagType,
+            $categoryLabel,
+            $recordsResolver,
+            $allowDrilldown,
+            \Filament\Tables\Actions\BulkAction::class,
+            true
+        );
+    }
+
+    public static function addToCustomPlaylistAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group',
+        ?callable $recordsResolver = null,
+        bool $allowDrilldown = true,
+        string $actionClass = \Filament\Tables\Actions\Action::class
+    ): \Filament\Actions\Action {
+        return self::buildAddToCustomPlaylistAction(
+            $modelClass,
+            $relation,
+            $sourceKey,
+            $itemLabel,
+            $tagType,
+            $categoryLabel,
+            $recordsResolver,
+            $allowDrilldown,
+            $actionClass,
+            false
+        );
     }
 }

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -5,8 +5,8 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\CategoryResource\Pages;
 use App\Filament\Resources\CategoryResource\RelationManagers;
 use App\Models\Category;
-use App\Models\CustomPlaylist;
 use App\Jobs\SyncPlaylistChildren;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -22,6 +22,8 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class CategoryResource extends Resource
 {
+    use HandlesSourcePlaylist;
+
     protected static ?string $model = Category::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -113,53 +115,16 @@ class CategoryResource extends Resource
             ->actions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\ViewAction::make(),
-                    Tables\Actions\Action::make('add')
-                        ->label('Add to Custom Playlist')
-                        ->form([
-                            Forms\Components\Select::make('playlist')
-                                ->required()
-                                ->live()
-                                ->label('Custom Playlist')
-                                ->helperText('Select the custom playlist you would like to add the selected series to.')
-                                ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                    if ($state) {
-                                        $set('category', null);
-                                    }
-                                })
-                                ->searchable(),
-                            Forms\Components\Select::make('category')
-                                ->label('Custom Category')
-                                ->disabled(fn(Get $get) => !$get('playlist'))
-                                ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the category you would like to assign to the selected series to.')
-                                ->options(function ($get) {
-                                    $customList = CustomPlaylist::find($get('playlist'));
-                                    return $customList ? $customList->tags()
-                                        ->where('type', $customList->uuid . '-category')
-                                        ->get()
-                                        ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                        ->toArray() : [];
-                                })
-                                ->searchable(),
-                        ])
-                        ->action(function ($record, array $data): void {
-                            $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                            $playlist->series()->syncWithoutDetaching($record->series()->pluck('id'));
-                            if ($data['category']) {
-                                $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title('Series added to custom playlist')
-                                ->body('The selected series have been added to the chosen custom playlist.')
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-play')
-                        ->modalIcon('heroicon-o-play')
-                        ->modalDescription('Add the selected series to the chosen custom playlist.')
-                        ->modalSubmitActionLabel('Add now'),
+                    self::addToCustomPlaylistAction(
+                        Category::class,
+                        'categories',
+                        'source_category_id',
+                        'category',
+                        '-category',
+                        'Custom Category',
+                        null,
+                        false
+                    ),
                     Tables\Actions\Action::make('move')
                         ->label('Move Series to Category')
                         ->form([
@@ -276,58 +241,16 @@ class CategoryResource extends Resource
             ], position: Tables\Enums\ActionsPosition::BeforeCells)
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\BulkAction::make('add')
-                        ->label('Add to Custom Playlist')
-                        ->form([
-                            Forms\Components\Select::make('playlist')
-                                ->required()
-                                ->live()
-                                ->label('Custom Playlist')
-                                ->helperText('Select the custom playlist you would like to add the selected category series to.')
-                                ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                    if ($state) {
-                                        $set('category', null);
-                                    }
-                                })
-                                ->searchable(),
-                            Forms\Components\Select::make('category')
-                                ->label('Custom Category')
-                                ->disabled(fn(Get $get) => !$get('playlist'))
-                                ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the category you would like to assign to the selected series to.')
-                                ->options(function ($get) {
-                                    $customList = CustomPlaylist::find($get('playlist'));
-                                    return $customList ? $customList->tags()
-                                        ->where('type', $customList->uuid . '-category')
-                                        ->get()
-                                        ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                        ->toArray() : [];
-                                })
-                                ->searchable(),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                            foreach ($records as $record) {
-                                // Sync the series to the custom playlist
-                                // This will add the series to the playlist without detaching existing ones
-                                // Prevents duplicates in the playlist
-                                $playlist->series()->syncWithoutDetaching($record->series()->pluck('id'));
-                                if ($data['category']) {
-                                    $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                                }
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title('Category series added to custom playlist')
-                                ->body('The selected category series have been added to the chosen custom playlist.')
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-play')
-                        ->modalIcon('heroicon-o-play')
-                        ->modalDescription('Add the selected category series to the chosen custom playlist.')
-                        ->modalSubmitActionLabel('Add now'),
+                    self::addToCustomPlaylistBulkAction(
+                        Category::class,
+                        'categories',
+                        'source_category_id',
+                        'category',
+                        '-category',
+                        'Custom Category',
+                        null,
+                        false
+                    ),
                     Tables\Actions\BulkAction::make('move')
                         ->label('Move Series to Category')
                         ->form([

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -4,15 +4,15 @@ namespace App\Filament\Resources;
 
 use App\Facades\LogoFacade;
 use App\Facades\ProxyFacade;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Filament\Resources\ChannelResource\Pages;
 use App\Infolists\Components\VideoPreview;
+use App\Jobs\SyncPlaylistChildren;
 use App\Models\Channel;
 use App\Models\ChannelFailover;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\Playlist;
-use App\Jobs\SyncPlaylistChildren;
-use App\Filament\BulkActions\HandlesSourcePlaylist;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -29,11 +29,11 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
-use Illuminate\Validation\ValidationException;
 
 class ChannelResource extends Resource
 {
     use HandlesSourcePlaylist;
+
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -361,56 +361,14 @@ class ChannelResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn (Get $get) => ! $get('playlist'))
-                            ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn () => ! $addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(
+                    Channel::class,
+                    'channels',
+                    'source_id',
+                    'channel',
+                    '',
+                    'Custom Group'
+                )->hidden(fn () => ! $addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([

--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -4,9 +4,10 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\GroupResource\Pages;
 use App\Filament\Resources\GroupResource\RelationManagers;
-use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\Channel;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Jobs\SyncPlaylistChildren;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -23,6 +24,8 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class GroupResource extends Resource
 {
+    use HandlesSourcePlaylist;
+
     protected static ?string $model = Group::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -137,53 +140,18 @@ class GroupResource extends Resource
             ->actions([
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\ViewAction::make(),
-                    Tables\Actions\Action::make('add')
-                        ->label('Add to Custom Playlist')
-                        ->form([
-                            Forms\Components\Select::make('playlist')
-                                ->required()
-                                ->live()
-                                ->label('Custom Playlist')
-                                ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                                ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                    if ($state) {
-                                        $set('category', null);
-                                    }
-                                })
-                                ->searchable(),
-                            Forms\Components\Select::make('category')
-                                ->label('Custom Group')
-                                ->disabled(fn(Get $get) => !$get('playlist'))
-                                ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                                ->options(function ($get) {
-                                    $customList = CustomPlaylist::find($get('playlist'));
-                                    return $customList ? $customList->tags()
-                                        ->where('type', $customList->uuid)
-                                        ->get()
-                                        ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                        ->toArray() : [];
-                                })
-                                ->searchable(),
+                    self::addToCustomPlaylistAction(
+                        Channel::class,
+                        'channels',
+                        'source_id',
+                        'channel',
+                        '',
+                        'Custom Group',
+                        fn ($records) => $records->load('channels')->map(fn ($group) => [
+                            'group'    => $group,
+                            'channels' => $group->channels,
                         ])
-                        ->action(function ($record, array $data): void {
-                            $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                            $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                            if ($data['category']) {
-                                $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title('Group channels added to custom playlist')
-                                ->body('The groups channels have been added to the chosen custom playlist.')
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-play')
-                        ->modalIcon('heroicon-o-play')
-                        ->modalDescription('Add the group channels to the chosen custom playlist.')
-                        ->modalSubmitActionLabel('Add now'),
+                    ),
                     Tables\Actions\Action::make('move')
                         ->label('Move Channels to Group')
                         ->form([
@@ -262,58 +230,18 @@ class GroupResource extends Resource
             ], position: Tables\Enums\ActionsPosition::BeforeCells)
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\BulkAction::make('add')
-                        ->label('Add to Custom Playlist')
-                        ->form([
-                            Forms\Components\Select::make('playlist')
-                                ->required()
-                                ->live()
-                                ->label('Custom Playlist')
-                                ->helperText('Select the custom playlist you would like to add the selected group channel(s) to.')
-                                ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                    if ($state) {
-                                        $set('category', null);
-                                    }
-                                })
-                                ->searchable(),
-                            Forms\Components\Select::make('category')
-                                ->label('Custom Group')
-                                ->disabled(fn(Get $get) => !$get('playlist'))
-                                ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                                ->options(function ($get) {
-                                    $customList = CustomPlaylist::find($get('playlist'));
-                                    return $customList ? $customList->tags()
-                                        ->where('type', $customList->uuid)
-                                        ->get()
-                                        ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                        ->toArray() : [];
-                                })
-                                ->searchable(),
+                    self::addToCustomPlaylistBulkAction(
+                        Channel::class,
+                        'channels',
+                        'source_id',
+                        'channel',
+                        '',
+                        'Custom Group',
+                        fn ($records) => $records->load('channels')->map(fn ($group) => [
+                            'group'    => $group,
+                            'channels' => $group->channels,
                         ])
-                        ->action(function (Collection $records, array $data): void {
-                            $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                            foreach ($records as $record) {
-                                // Sync the channels to the custom playlist
-                                // This will add the channels to the playlist without detaching existing ones
-                                // Prevents duplicates in the playlist
-                                $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                                if ($data['category']) {
-                                    $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                                }
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title('Group channels added to custom playlist')
-                                ->body('The groups channels have been added to the chosen custom playlist.')
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-play')
-                        ->modalIcon('heroicon-o-play')
-                        ->modalDescription('Add the group channels to the chosen custom playlist.')
-                        ->modalSubmitActionLabel('Add now'),
+                    ),
                     Tables\Actions\BulkAction::make('move')
                         ->label('Move Channels to Group')
                         ->form([

--- a/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
+++ b/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
@@ -3,9 +3,10 @@
 namespace App\Filament\Resources\GroupResource\Pages;
 
 use App\Filament\Resources\GroupResource;
-use App\Models\CustomPlaylist;
 use App\Models\Group;
+use App\Models\Channel;
 use App\Jobs\SyncPlaylistChildren;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
@@ -14,61 +15,25 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewGroup extends ViewRecord
 {
+    use HandlesSourcePlaylist;
+
     protected static string $resource = GroupResource::class;
 
     protected function getHeaderActions(): array
     {
         return [
             Actions\ActionGroup::make([
-                Actions\Action::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add group channels to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the channels to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function ($record, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                        SyncPlaylistChildren::debounce($record->playlist, []);
-                    })->after(function ($livewire) {
-                        $livewire->dispatch('refreshRelation');
-                        Notification::make()
-                            ->success()
-                            ->title('Group channels added to custom playlist')
-                            ->body('The groups channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the group channels to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistAction(
+                    Channel::class,
+                    'channels',
+                    'source_id',
+                    'channel',
+                    '',
+                    'Custom Group',
+                    fn ($records) => $records->first()->channels,
+                    true,
+                    Actions\Action::class
+                ),
                 Actions\Action::make('move')
                     ->label('Move to Group')
                     ->form([

--- a/app/Filament/Resources/VodResource.php
+++ b/app/Filament/Resources/VodResource.php
@@ -420,56 +420,14 @@ class VodResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn (Get $get) => ! $get('playlist'))
-                            ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn () => ! $addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(
+                    Channel::class,
+                    'channels',
+                    'source_id',
+                    'channel',
+                    '',
+                    'Custom Group'
+                )->hidden(fn () => ! $addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([


### PR DESCRIPTION
## Summary
- group duplicate channels by parent group in source-playlist handler
- allow viewing and overriding channels in paginated steppers
- resolve group actions to grouped channel collections
- remove obsolete CustomPlaylist imports after handler migration
- disable per-series drilldown when adding categories to custom playlists
- group duplicates by category source ID and disable series drilldown

## Testing
- `composer install --no-interaction --no-progress`
- `BROADCAST_CONNECTION=log php artisan migrate --force`
- `BROADCAST_CONNECTION=log ./vendor/bin/pest tests/Feature/ChannelAddToCustomPlaylistTest.php` *(fails: Tests: 3 failed (0 assertions))*

------
https://chatgpt.com/codex/tasks/task_e_68bd5ac7e8a08321adcc280f274beb09