### PR TITLE
Track fallback keys for unnamed groups

### DIFF
--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 use App\Models\Concerns\DispatchesPlaylistSync;
 
 class Group extends Model
@@ -15,10 +16,16 @@ class Group extends Model
 
     protected function playlistSyncChanges(): array
     {
-        return ['groups' => array_filter([
-            $this->name_internal,
-            $this->getOriginal('name_internal'),
-        ])];
+        $current = $this->name_internal
+            ?? (Str::slug((string) $this->name) ?: 'grp-' . $this->id);
+
+        $original = $this->getOriginal('name_internal')
+            ?? (Str::slug((string) $this->getOriginal('name')) ?: 'grp-' . $this->id);
+
+        return ['groups' => array_unique(array_filter([
+            $current,
+            $original,
+        ]))];
     }
 
     /**


### PR DESCRIPTION
## Summary
- compute fallback slugs for groups lacking `name_internal`
- handle fallback keys during playlist sync to propagate renames and deletions
- test syncing, renaming, and deleting unnamed groups

## Testing
- `vendor/bin/pest tests/Feature/PlaylistSyncTest.php --filter="without internal names"`


------
https://chatgpt.com/codex/tasks/task_e_68bd896099488321b02d7f1e2e5d8793