### PR TITLE
Simplify tag selection in custom playlist relation managers

### DIFF
--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -238,14 +238,10 @@ class ChannelsRelationManager extends RelationManager
                         Forms\Components\Select::make('group')
                             ->label('Select group')
                             ->options(
-                                Tag::query()
-                                    ->where('type', $ownerRecord->uuid)
-                                    ->get()
-                                    ->map(fn($name) => [
-                                        'id' => $name->getAttributeValue('name'),
-                                        'name' => $name->getAttributeValue('name')
-                                    ])->pluck('id', 'name')
-                            )->required(),
+                                Tag::where('type', $ownerRecord->uuid)
+                                    ->pluck('name', 'name')
+                            )
+                            ->required(),
                     ])
                     ->action(function (Collection $records, $data) use ($ownerRecord): void {
                         foreach ($records as $record) {

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -209,16 +209,12 @@ class SeriesRelationManager extends RelationManager
                     ->label('Add to custom category')
                     ->form([
                         Forms\Components\Select::make('category')
-                            ->label('Select group')
+                            ->label('Select category')
                             ->options(
-                                Tag::query()
-                                    ->where('type', $ownerRecord->uuid . '-category')
-                                    ->get()
-                                    ->map(fn($name) => [
-                                        'id' => $name->getAttributeValue('name'),
-                                        'name' => $name->getAttributeValue('name')
-                                    ])->pluck('id', 'name')
-                            )->required(),
+                                Tag::where('type', $ownerRecord->uuid . '-category')
+                                    ->pluck('name', 'name')
+                            )
+                            ->required(),
                     ])
                     ->action(function (Collection $records, $data) use ($ownerRecord): void {
                         foreach ($records as $record) {


### PR DESCRIPTION
## Summary
- streamline tag option retrieval in channel and series bulk actions
- rename series modal field label to "Select category"

## Testing
- `php artisan test` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68bd898d5d608321bd4150cead6f0f90