### PR TITLE
Handle source ID changes during playlist sync

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -561,9 +561,15 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
             $groupKeys = [];
             $pendingFailovers = [];
             foreach ($channelSources as $source) {
-                $channel = str_starts_with($source, 'ch-')
-                ? $parent->channels()->with('failovers.channelFailover', 'group')->find(substr($source, 3))
-                : $parent->channels()->with('failovers.channelFailover', 'group')->where('source_id', $source)->first();
+                $channel = null;
+                if (str_starts_with($source, 'ch-')) {
+                    $channel = $parent->channels()->with('failovers.channelFailover', 'group')->find(substr($source, 3));
+                    if ($channel && ($channel->source_id ?? 'ch-' . $channel->id) !== $source) {
+                        $channel = null;
+                    }
+                } else {
+                    $channel = $parent->channels()->with('failovers.channelFailover', 'group')->where('source_id', $source)->first();
+                }
 
                 if ($channel) {
                     $groupKey = $channel->group?->name_internal;
@@ -617,9 +623,15 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
         $categorySources = $changes['categories'] ?? [];
         if (! empty($categorySources)) {
             foreach ($categorySources as $source) {
-                $category = str_starts_with($source, 'cat-')
-                    ? $parent->categories()->find(substr($source, 4))
-                    : $parent->categories()->where('source_category_id', $source)->first();
+                $category = null;
+                if (str_starts_with($source, 'cat-')) {
+                    $category = $parent->categories()->find(substr($source, 4));
+                    if ($category && ($category->source_category_id ?? 'cat-' . $category->id) !== $source) {
+                        $category = null;
+                    }
+                } else {
+                    $category = $parent->categories()->where('source_category_id', $source)->first();
+                }
 
                 if ($category) {
                     $childCategory = $child->categories()->firstOrNew([
@@ -638,9 +650,15 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
         $seriesSources = $changes['series'] ?? [];
         if (! empty($seriesSources)) {
             foreach ($seriesSources as $source) {
-                $series = str_starts_with($source, 'series-')
-                    ? $parent->series()->find(substr($source, 7))
-                    : $parent->series()->where('source_series_id', $source)->first();
+                $series = null;
+                if (str_starts_with($source, 'series-')) {
+                    $series = $parent->series()->find(substr($source, 7));
+                    if ($series && ($series->source_series_id ?? 'series-' . $series->id) !== $source) {
+                        $series = null;
+                    }
+                } else {
+                    $series = $parent->series()->where('source_series_id', $source)->first();
+                }
 
                 if ($series) {
                     $categorySource = $series->category?->source_category_id
@@ -669,9 +687,15 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
         $seasonSources = $changes['seasons'] ?? [];
         if (! empty($seasonSources)) {
             foreach ($seasonSources as $source) {
-                $season = str_starts_with($source, 'season-')
-                    ? $parent->seasons()->find(substr($source, 7))
-                    : $parent->seasons()->where('source_season_id', $source)->first();
+                $season = null;
+                if (str_starts_with($source, 'season-')) {
+                    $season = $parent->seasons()->find(substr($source, 7));
+                    if ($season && ($season->source_season_id ?? 'season-' . $season->id) !== $source) {
+                        $season = null;
+                    }
+                } else {
+                    $season = $parent->seasons()->where('source_season_id', $source)->first();
+                }
 
                 if ($season) {
                     $seriesSource = $season->series?->source_series_id
@@ -701,9 +725,15 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
         $episodeSources = $changes['episodes'] ?? [];
         if (! empty($episodeSources)) {
             foreach ($episodeSources as $source) {
-                $episode = str_starts_with($source, 'ep-')
-                    ? $parent->episodes()->find(substr($source, 3))
-                    : $parent->episodes()->where('source_episode_id', $source)->first();
+                $episode = null;
+                if (str_starts_with($source, 'ep-')) {
+                    $episode = $parent->episodes()->find(substr($source, 3));
+                    if ($episode && ($episode->source_episode_id ?? 'ep-' . $episode->id) !== $source) {
+                        $episode = null;
+                    }
+                } else {
+                    $episode = $parent->episodes()->where('source_episode_id', $source)->first();
+                }
 
                 if ($episode) {
                     $seasonSource = $episode->season?->source_season_id

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -17,9 +17,13 @@ class Category extends Model
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_category_id ?? 'cat-'.$this->id;
+        $current = $this->source_category_id ?? 'cat-' . $this->id;
+        $original = $this->getOriginal('source_category_id') ?? 'cat-' . $this->id;
 
-        return ['categories' => [$source]];
+        return ['categories' => array_unique(array_filter([
+            $current,
+            $original,
+        ]))];
     }
 
     /**

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -60,8 +60,13 @@ class Channel extends Model
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_id ?? 'ch-' . $this->id;
-        return ['channels' => [$source]];
+        $current = $this->source_id ?? 'ch-' . $this->id;
+        $original = $this->getOriginal('source_id') ?? 'ch-' . $this->id;
+
+        return ['channels' => array_unique(array_filter([
+            $current,
+            $original,
+        ]))];
     }
 
     /**

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -16,9 +16,13 @@ class Episode extends Model
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_episode_id ?? 'ep-'.$this->id;
+        $current = $this->source_episode_id ?? 'ep-' . $this->id;
+        $original = $this->getOriginal('source_episode_id') ?? 'ep-' . $this->id;
 
-        return ['episodes' => [$source]];
+        return ['episodes' => array_unique(array_filter([
+            $current,
+            $original,
+        ]))];
     }
 
     /**

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -17,9 +17,13 @@ class Season extends Model
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_season_id ?? 'season-'.$this->id;
+        $current = $this->source_season_id ?? 'season-' . $this->id;
+        $original = $this->getOriginal('source_season_id') ?? 'season-' . $this->id;
 
-        return ['seasons' => [$source]];
+        return ['seasons' => array_unique(array_filter([
+            $current,
+            $original,
+        ]))];
     }
 
     /**

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -24,9 +24,13 @@ class Series extends Model
 
     protected function playlistSyncChanges(): array
     {
-        $source = $this->source_series_id ?? 'series-'.$this->id;
+        $current = $this->source_series_id ?? 'series-' . $this->id;
+        $original = $this->getOriginal('source_series_id') ?? 'series-' . $this->id;
 
-        return ['series' => [$source]];
+        return ['series' => array_unique(array_filter([
+            $current,
+            $original,
+        ]))];
     }
 
     /**

--- a/tests/Feature/PlaylistDeltaSyncTest.php
+++ b/tests/Feature/PlaylistDeltaSyncTest.php
@@ -148,6 +148,18 @@ it('deletes a channel without touching others', function () {
     expect($childCh2->updated_at)->toEqual($oldUpdated);
 });
 
+it('removes old channel entry when source id changes', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2] = createSyncedPair();
+
+    $oldSource = 'ch-' . $ch1->id;
+    $ch1->forceFill(['source_id' => 'new-channel'])->save();
+    SyncPlaylistChildren::debounce($parent, ['channels' => ['new-channel', $oldSource]]);
+    (new SyncPlaylistChildren($parent))->handle();
+
+    expect($child->channels()->where('source_id', 'new-channel')->exists())->toBeTrue();
+    expect($child->channels()->where('source_id', $oldSource)->exists())->toBeFalse();
+});
+
 it('keeps child failover reference after a channel update', function () {
     $playlist = Playlist::factory()->create();
     $group = Group::factory()->create([
@@ -223,6 +235,18 @@ it('deletes a category without touching others', function () {
     expect($childCatB->updated_at)->toEqual($oldUpdated);
 });
 
+it('removes old category entry when source id changes', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB] = createSyncedPair();
+
+    $oldSource = 'cat-' . $catA->id;
+    $catA->forceFill(['source_category_id' => 'new-category'])->save();
+    SyncPlaylistChildren::debounce($parent, ['categories' => ['new-category', $oldSource]]);
+    (new SyncPlaylistChildren($parent))->handle();
+
+    expect($child->categories()->where('source_category_id', 'new-category')->exists())->toBeTrue();
+    expect($child->categories()->where('source_category_id', $oldSource)->exists())->toBeFalse();
+});
+
 it('renames a series without touching others', function () {
     [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2] = createSyncedPair();
 
@@ -254,6 +278,18 @@ it('deletes a series without touching others', function () {
     expect($childSeries2->updated_at)->toEqual($oldUpdated);
 });
 
+it('removes old series entry when source id changes', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode] = createSyncedPair();
+
+    $oldSource = 'series-' . $series1->id;
+    $series1->forceFill(['source_series_id' => 'new-series'])->save();
+    SyncPlaylistChildren::debounce($parent, ['series' => ['new-series', $oldSource]]);
+    (new SyncPlaylistChildren($parent))->handle();
+
+    expect($child->series()->where('source_series_id', 'new-series')->exists())->toBeTrue();
+    expect($child->series()->where('source_series_id', $oldSource)->exists())->toBeFalse();
+});
+
 it('renames a season without touching its episodes', function () {
     [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode] = createSyncedPair();
 
@@ -279,6 +315,18 @@ it('deletes a season and its episodes', function () {
 
     expect($child->seasons()->where('source_season_id', $source)->exists())->toBeFalse();
     expect($child->episodes()->where('source_episode_id', 'ep-' . $episode->id)->exists())->toBeFalse();
+});
+
+it('removes old season entry when source id changes', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode] = createSyncedPair();
+
+    $oldSource = 'season-' . $season->id;
+    $season->forceFill(['source_season_id' => 'new-season'])->save();
+    SyncPlaylistChildren::debounce($parent, ['seasons' => ['new-season', $oldSource]]);
+    (new SyncPlaylistChildren($parent))->handle();
+
+    expect($child->seasons()->where('source_season_id', 'new-season')->exists())->toBeTrue();
+    expect($child->seasons()->where('source_season_id', $oldSource)->exists())->toBeFalse();
 });
 
 it('renames an episode without touching its season', function () {
@@ -310,6 +358,18 @@ it('deletes an episode without touching its season', function () {
     expect($child->episodes()->where('source_episode_id', $source)->exists())->toBeFalse();
     $childSeason->refresh();
     expect($childSeason->updated_at)->toEqual($oldUpdated);
+});
+
+it('removes old episode entry when source id changes', function () {
+    [$parent, $child, $groupA, $groupB, $ch1, $ch2, $catA, $catB, $series1, $series2, $season, $episode] = createSyncedPair();
+
+    $oldSource = 'ep-' . $episode->id;
+    $episode->forceFill(['source_episode_id' => 'new-episode'])->save();
+    SyncPlaylistChildren::debounce($parent, ['episodes' => ['new-episode', $oldSource]]);
+    (new SyncPlaylistChildren($parent))->handle();
+
+    expect($child->episodes()->where('source_episode_id', 'new-episode')->exists())->toBeTrue();
+    expect($child->episodes()->where('source_episode_id', $oldSource)->exists())->toBeFalse();
 });
 
 it('coalesces multiple channel renames into one job', function () {


### PR DESCRIPTION
## Summary
- include current and original source identifiers in playlist sync change detection for channels, categories, series, seasons and episodes
- ensure syncDelta reconciles renamed sources, deleting stale child records
- add feature tests for removing stale child entries after parent source id changes

## Testing
- `./vendor/bin/pest tests/Feature/PlaylistDeltaSyncTest.php --filter="renames a channel without touching others"` *(fails: Connection refused [tcp://127.0.0.1:36790])*

------
https://chatgpt.com/codex/tasks/task_e_68bd8fa46b508321a482d7390c710c0e