### PR TITLE
Fix PostgreSQL JSONB upsert

### DIFF
--- a/app/Jobs/SyncPlaylistChildren.php
+++ b/app/Jobs/SyncPlaylistChildren.php
@@ -84,7 +84,7 @@ class SyncPlaylistChildren implements ShouldBeUnique, ShouldQueue
                     ]],
                     ['playlist_id', 'change_type'],
                     [
-                        'item_ids' => DB::raw("(select jsonb_agg(distinct value) from jsonb_array_elements(coalesce(playlist_sync_changes.item_ids, '[]'::jsonb) || excluded.item_ids) as t(value))"),
+                        'item_ids' => DB::raw("(select jsonb_agg(distinct value) from jsonb_array_elements(coalesce(playlist_sync_changes.item_ids::jsonb, '[]'::jsonb) || excluded.item_ids::jsonb) as t(value))"),
                         'updated_at' => $now,
                     ]
                 );


### PR DESCRIPTION
## Summary
- Cast `playlist_sync_changes.item_ids` and `excluded.item_ids` to JSONB for PostgreSQL upserts

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bd985a75248321927f0faadb8ad440