### PR TITLE
Fix EPG mapping failure by removing unused channels column update

### DIFF
--- a/app/Jobs/MapPlaylistChannelsToEpg.php
+++ b/app/Jobs/MapPlaylistChannelsToEpg.php
@@ -261,7 +261,6 @@ class MapPlaylistChannelsToEpg implements ShouldQueue
                         ->sendToDatabase($epg->user);
                     $map->update([
                         'status' => Status::Failed,
-                        'channels' => 0, // not using...
                         'errors' => $error,
                         'progress' => 100,
                         'processing' => false,


### PR DESCRIPTION
## Summary
- avoid updating non-existent `channels` column when mapping fails

## Testing
- `./vendor/bin/pest` *(fails: no such table: users)*
- `./vendor/bin/pint --test` *(fails: multiple formatting violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1f1038c83219be46960c1cb1143