### PR TITLE
Fix custom playlist action return type

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -48,19 +48,19 @@ trait HandlesSourcePlaylist
     /**
      * Build duplicate playlist metadata for the given records.
      *
-     * @param Collection $records   Selected records from the bulk action.
-     * @param string     $relation  Relationship name used to query playlist items (channels, series, etc.).
-     * @param string     $sourceKey Source identifier column on the related model.
+     * @param  Collection  $records  Selected records from the bulk action.
+     * @param  string  $relation  Relationship name used to query playlist items (channels, series, etc.).
+     * @param  string  $sourceKey  Source identifier column on the related model.
      * @return array{0: Collection, 1: bool, 2: Collection, 3: Collection} Tuple containing
-     *                                             duplicate groups, whether a source playlist is
-     *                                             needed, the source IDs of the records, and a
-     *                                             map of composite playlist/source keys to their
-     *                                             parent-child group key.
-    */
+     *                                                                     duplicate groups, whether a source playlist is
+     *                                                                     needed, the source IDs of the records, and a
+     *                                                                     map of composite playlist/source keys to their
+     *                                                                     parent-child group key.
+     */
     protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
     {
         $recordPlaylistIds = $records->pluck('playlist_id')->unique();
-        $recordSourceIds   = $records->pluck($sourceKey)->filter()->unique();
+        $recordSourceIds = $records->pluck($sourceKey)->filter()->unique();
 
         $parentIds = Playlist::whereIn('id', $recordPlaylistIds)
             ->pluck('parent_id')
@@ -92,7 +92,7 @@ trait HandlesSourcePlaylist
 
         $playlists
             ->flatMap(fn ($playlist) => $playlist->$relation->map(fn ($item) => [
-                'source_id'   => $item->$sourceKey,
+                'source_id' => $item->$sourceKey,
                 'playlist_id' => $playlist->id,
             ]))
             ->groupBy('source_id')
@@ -107,21 +107,21 @@ trait HandlesSourcePlaylist
                     $playlist = $playlistMap[$id];
 
                     if ($playlist->parent_id && $ids->contains($playlist->parent_id)) {
-                        $pairKey = $playlist->parent_id . '-' . $id;
+                        $pairKey = $playlist->parent_id.'-'.$id;
 
                         $groups[$pairKey] ??= [
-                            'parent_id'     => $playlist->parent_id,
-                            'child_id'      => $id,
-                            'playlists'     => $playlistMap
+                            'parent_id' => $playlist->parent_id,
+                            'child_id' => $id,
+                            'playlists' => $playlistMap
                                 ->only([$playlist->parent_id, $id])
                                 ->map->name,
-                            'source_ids'    => [],
-                            'composite_keys'=> [],
+                            'source_ids' => [],
+                            'composite_keys' => [],
                         ];
 
-                        $groups[$pairKey]['source_ids'][]     = $sourceId;
-                        $groups[$pairKey]['composite_keys'][] = $id . ':' . $sourceId;
-                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id . ':' . $sourceId;
+                        $groups[$pairKey]['source_ids'][] = $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $id.':'.$sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id.':'.$sourceId;
                     }
                 }
             });
@@ -136,8 +136,8 @@ trait HandlesSourcePlaylist
 
         // Store the selected record details under their respective group
         foreach ($records as $record) {
-            $sourceId  = $record->$sourceKey;
-            $composite = $record->playlist_id . ':' . $sourceId;
+            $sourceId = $record->$sourceKey;
+            $composite = $record->playlist_id.':'.$sourceId;
 
             if (! $sourceToGroup->has($composite)) {
                 continue;
@@ -147,9 +147,9 @@ trait HandlesSourcePlaylist
 
             $group = $duplicateGroups[$pairKey];
             $group['records'][$record->id] = [
-                'id'          => $record->id,
-                'title'       => $record->title ?? $record->name ?? '',
-                'source_id'   => $sourceId,
+                'id' => $record->id,
+                'title' => $record->title ?? $record->name ?? '',
+                'source_id' => $sourceId,
                 'playlist_id' => $record->playlist_id,
             ];
             $duplicateGroups[$pairKey] = $group;
@@ -165,13 +165,13 @@ trait HandlesSourcePlaylist
      * duplicate parent/child groups and optionally override individual
      * records within those groups.
      *
-     * @param Collection      $records            Records selected in the bulk action.
-     * @param string          $relation           Relationship name used to fetch playlist items.
-     * @param string          $sourceKey          Column containing the source ID on the related model.
-     * @param string          $itemLabel          Human-readable label for the record type (channel, series, etc.).
-     * @param array|null      $sourcePlaylistData Cached metadata returned from {@see getSourcePlaylistData}.
-     *                                           Passed by reference so callers can reuse the computed data.
-     * @return array                             Array of Filament form components for inclusion in the bulk action.
+     * @param  Collection  $records  Records selected in the bulk action.
+     * @param  string  $relation  Relationship name used to fetch playlist items.
+     * @param  string  $sourceKey  Column containing the source ID on the related model.
+     * @param  string  $itemLabel  Human-readable label for the record type (channel, series, etc.).
+     * @param  array|null  $sourcePlaylistData  Cached metadata returned from {@see getSourcePlaylistData}.
+     *                                          Passed by reference so callers can reuse the computed data.
+     * @return array Array of Filament form components for inclusion in the bulk action.
      */
     protected static function buildSourcePlaylistForm(
         Collection $records,
@@ -185,13 +185,13 @@ trait HandlesSourcePlaylist
         if ($sourcePlaylistData === null) {
             if ($grouped) {
                 // Map each record and composite key to its parent group
-                $recordGroups    = [];
+                $recordGroups = [];
                 $compositeGroups = [];
                 foreach ($grouped as $groupEntry) {
                     $groupId = $groupEntry['group']->id;
                     foreach ($groupEntry['channels'] as $channel) {
                         $recordGroups[$channel->id] = $groupId;
-                        $compositeGroups[$channel->playlist_id . ':' . $channel->$sourceKey] = $groupId;
+                        $compositeGroups[$channel->playlist_id.':'.$channel->$sourceKey] = $groupId;
                     }
                 }
 
@@ -208,8 +208,8 @@ trait HandlesSourcePlaylist
                             continue;
                         }
 
-                        $globalKey = $gid . '|' . $pairKey;
-                        $existing  = $groupedDuplicates[$globalKey] ?? array_merge($group, ['records' => []]);
+                        $globalKey = $gid.'|'.$pairKey;
+                        $existing = $groupedDuplicates[$globalKey] ?? array_merge($group, ['records' => []]);
                         $existing['records'][$record['id']] = $record;
                         $groupedDuplicates[$globalKey] = $existing;
                     }
@@ -218,7 +218,8 @@ trait HandlesSourcePlaylist
                 // Map composite keys to the new global pair keys
                 $globalSourceToGroup = $sourceToGroup->map(function ($pairKey, $composite) use ($compositeGroups) {
                     $gid = $compositeGroups[$composite] ?? null;
-                    return $gid !== null ? $gid . '|' . $pairKey : $pairKey;
+
+                    return $gid !== null ? $gid.'|'.$pairKey : $pairKey;
                 });
 
                 $sourcePlaylistData = [
@@ -249,7 +250,7 @@ trait HandlesSourcePlaylist
             $fields = [];
             foreach ($grouped as $groupEntry) {
                 $groupModel = $groupEntry['group'];
-                $groupId    = (string) $groupModel->id;
+                $groupId = (string) $groupModel->id;
                 if (! isset($byGroup[$groupId])) {
                     continue;
                 }
@@ -257,10 +258,10 @@ trait HandlesSourcePlaylist
                 $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
                     ->schema([
                         Forms\Components\Fieldset::make($groupModel->name)
-                            ->schema(collect($byGroup[$groupId])->map(function ($group, $pairKey) use ($groupId, $itemLabel, $allowDrilldown) {
-                                $globalKey  = $groupId . '|' . $pairKey;
+                            ->schema(collect($byGroup[$groupId])->map(function ($group, $pairKey) use ($groupId, $allowDrilldown) {
+                                $globalKey = $groupId.'|'.$pairKey;
                                 $parentName = $group['playlists'][$group['parent_id']];
-                                $childName  = $group['playlists'][$group['child_id']];
+                                $childName = $group['playlists'][$group['child_id']];
 
                                 $schema = [
                                     Forms\Components\Select::make("source_playlists.{$globalKey}")
@@ -294,7 +295,7 @@ trait HandlesSourcePlaylist
 
         foreach ($duplicateGroups as $pairKey => $group) {
             $parentName = $group['playlists'][$group['parent_id']];
-            $childName  = $group['playlists'][$group['child_id']];
+            $childName = $group['playlists'][$group['child_id']];
 
             $schema = [
                 Forms\Components\Select::make("source_playlists.{$pairKey}")
@@ -329,14 +330,13 @@ trait HandlesSourcePlaylist
         $chunks = $records->chunk(10);
         $steps = [];
         foreach ($chunks as $index => $chunk) {
-            $steps[] = Forms\Components\Wizard\Step::make('Page ' . ($index + 1))
+            $steps[] = Forms\Components\Wizard\Step::make('Page '.($index + 1))
                 ->schema(
-                    $chunk->map(fn ($record) =>
-                        Forms\Components\Select::make((string) $record['id'])
-                            ->label($record['title'])
-                            ->options($playlists->toArray())
-                            ->placeholder('Use group selection')
-                            ->searchable()
+                    $chunk->map(fn ($record) => Forms\Components\Select::make((string) $record['id'])
+                        ->label($record['title'])
+                        ->options($playlists->toArray())
+                        ->placeholder('Use group selection')
+                        ->searchable()
                     )->toArray()
                 );
         }
@@ -365,15 +365,16 @@ trait HandlesSourcePlaylist
      * source playlist chosen, and replaces records with their counterpart from
      * the selected source playlist.
      *
-     * @param Collection $records           Records originally selected in the bulk action.
-     * @param array      $data              Form data submitted by the user.
-     * @param string     $relation          Relationship name used to fetch playlist items.
-     * @param string     $sourceKey         Source identifier column on the related model.
-     * @param string     $modelClass        Fully qualified model class name for the records.
-     * @param array|null $sourcePlaylistData Cached metadata from {@see getSourcePlaylistData}.
-     *                                       Passed by reference to avoid recomputation.
-     * @return Collection                    Collection of records mapped to their chosen source playlist.
-     * @throws ValidationException           If any duplicate group lacks a source selection.
+     * @param  Collection  $records  Records originally selected in the bulk action.
+     * @param  array  $data  Form data submitted by the user.
+     * @param  string  $relation  Relationship name used to fetch playlist items.
+     * @param  string  $sourceKey  Source identifier column on the related model.
+     * @param  string  $modelClass  Fully qualified model class name for the records.
+     * @param  array|null  $sourcePlaylistData  Cached metadata from {@see getSourcePlaylistData}.
+     *                                          Passed by reference to avoid recomputation.
+     * @return Collection Collection of records mapped to their chosen source playlist.
+     *
+     * @throws ValidationException If any duplicate group lacks a source selection.
      */
     protected static function mapRecordsToSourcePlaylist(
         Collection $records,
@@ -390,13 +391,13 @@ trait HandlesSourcePlaylist
         [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
 
         if ($needsSourcePlaylist) {
-            $selected     = collect($data['source_playlists'] ?? []);
+            $selected = collect($data['source_playlists'] ?? []);
             $itemSelected = collect($data['source_playlists_items'] ?? []);
 
             foreach ($duplicateGroups as $pairKey => $group) {
-                $bulk   = $selected[$pairKey] ?? null;
-                $items  = collect($itemSelected[$pairKey] ?? [])->filter();
-                $count  = count($group['records'] ?? []);
+                $bulk = $selected[$pairKey] ?? null;
+                $items = collect($itemSelected[$pairKey] ?? [])->filter();
+                $count = count($group['records'] ?? []);
 
                 if (! $bulk && $items->count() !== $count) {
                     throw ValidationException::withMessages([
@@ -419,12 +420,12 @@ trait HandlesSourcePlaylist
                 ->map->keyBy($sourceKey);
 
             $records = $records->map(function ($record) use ($selected, $itemSelected, $sourceMaps, $sourceToGroup, $sourceKey) {
-                $sourceId  = $record->$sourceKey;
-                $composite = $record->playlist_id . ':' . $sourceId;
+                $sourceId = $record->$sourceKey;
+                $composite = $record->playlist_id.':'.$sourceId;
 
                 if ($sourceToGroup->has($composite)) {
-                    $pairKey    = $sourceToGroup[$composite];
-                    $override   = $itemSelected[$pairKey][$record->id] ?? null;
+                    $pairKey = $sourceToGroup[$composite];
+                    $override = $itemSelected[$pairKey][$record->id] ?? null;
                     $playlistId = $override ?: ($selected[$pairKey] ?? null);
 
                     return $playlistId && isset($sourceMaps[$playlistId][$sourceId])
@@ -443,12 +444,12 @@ trait HandlesSourcePlaylist
      * Construct a Filament bulk action that adds the selected records to a
      * custom playlist, including optional source playlist disambiguation.
      *
-     * @param string $modelClass    Fully qualified model class for the records.
-     * @param string $relation      Relationship name used by the custom playlist (channels, series, vods).
-     * @param string $sourceKey     Column containing the source ID on the related model.
-     * @param string $itemLabel     Human-readable label for the record type.
-     * @param string $tagType       Tag type used when assigning categories/groups.
-     * @param string $categoryLabel Label displayed for the category select.
+     * @param  string  $modelClass  Fully qualified model class for the records.
+     * @param  string  $relation  Relationship name used by the custom playlist (channels, series, vods).
+     * @param  string  $sourceKey  Column containing the source ID on the related model.
+     * @param  string  $itemLabel  Human-readable label for the record type.
+     * @param  string  $tagType  Tag type used when assigning categories/groups.
+     * @param  string  $categoryLabel  Label displayed for the category select.
      * @return Tables\Actions\Action Configured action ready to attach to a Filament table.
      */
     protected static function buildAddToCustomPlaylistAction(
@@ -462,10 +463,10 @@ trait HandlesSourcePlaylist
         bool $allowDrilldown = true,
         string $actionClass = \Filament\Tables\Actions\BulkAction::class,
         bool $isBulk = true
-    ): \Filament\Actions\Action {
+    ): \Filament\Tables\Actions\Action {
         $sourcePlaylistData = null;
 
-        /** @var \Filament\Actions\Action $action */
+        /** @var \Filament\Tables\Actions\Action $action */
         $action = $actionClass::make('add')
             ->label('Add to Custom Playlist')
             ->form(function ($records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData, $recordsResolver, $isBulk, $allowDrilldown): array {
@@ -490,12 +491,13 @@ trait HandlesSourcePlaylist
                         ->disabled(fn (Get $get) => ! $get('playlist'))
                         ->helperText(fn (Get $get) => ! $get('playlist')
                             ? 'Select a custom playlist first.'
-                            : 'Select the ' . ($categoryLabel === 'Custom Group' ? 'group' : 'category') .
-                                ' you would like to assign to the selected ' . $itemLabel . ' to.')
+                            : 'Select the '.($categoryLabel === 'Custom Group' ? 'group' : 'category').
+                                ' you would like to assign to the selected '.$itemLabel.' to.')
                         ->options(function ($get) use ($tagType) {
                             $customList = CustomPlaylist::find($get('playlist'));
+
                             return $customList ? $customList->tags()
-                                ->where('type', $customList->uuid . $tagType)
+                                ->where('type', $customList->uuid.$tagType)
                                 ->get()
                                 ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
                                 ->toArray() : [];
@@ -533,7 +535,7 @@ trait HandlesSourcePlaylist
             ->after(function () use ($itemLabel) {
                 Notification::make()
                     ->success()
-                    ->title(ucfirst($itemLabel) . ' added to custom playlist')
+                    ->title(ucfirst($itemLabel).' added to custom playlist')
                     ->body("The selected {$itemLabel} have been added to the chosen custom playlist.")
                     ->send();
             })
@@ -584,7 +586,7 @@ trait HandlesSourcePlaylist
         ?callable $recordsResolver = null,
         bool $allowDrilldown = true,
         string $actionClass = \Filament\Tables\Actions\Action::class
-    ): \Filament\Actions\Action {
+    ): \Filament\Tables\Actions\Action {
         return self::buildAddToCustomPlaylistAction(
             $modelClass,
             $relation,


### PR DESCRIPTION
## Summary
- ensure custom playlist builder returns table actions instead of generic actions

## Testing
- `./vendor/bin/pint app/Filament/BulkActions/HandlesSourcePlaylist.php`
- `./vendor/bin/pest` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bda5bfe32c8321946e2096404d4003