### PR TITLE
fix: guard against missing relations in source playlist data

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -91,10 +91,11 @@ trait HandlesSourcePlaylist
         $groups = [];
 
         $playlists
-            ->flatMap(fn ($playlist) => $playlist->$relation->map(fn ($item) => [
-                'source_id' => $item->$sourceKey,
-                'playlist_id' => $playlist->id,
-            ]))
+            ->flatMap(fn ($playlist) => ($playlist->$relation ?? collect())
+                ->map(fn ($item) => [
+                    'source_id' => $item->$sourceKey,
+                    'playlist_id' => $playlist->id,
+                ]))
             ->groupBy('source_id')
             ->each(function ($group, $sourceId) use (&$groups, $playlistMap) {
                 $ids = $group->pluck('playlist_id')->unique();


### PR DESCRIPTION
## Summary
- avoid null error in `getSourcePlaylistData` when a playlist relation isn't loaded

## Testing
- `./vendor/bin/pest` *(fails: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaf6271988321afdb99a55d5218cd