### PR TITLE
Prevent null relation map errors in playlist bulk actions

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -91,7 +91,7 @@ trait HandlesSourcePlaylist
         $groups = [];
 
         $playlists
-            ->flatMap(fn ($playlist) => ($playlist->$relation ?? collect())
+            ->flatMap(fn ($playlist) => collect($playlist->$relation)
                 ->map(fn ($item) => [
                     'source_id' => $item->$sourceKey,
                     'playlist_id' => $playlist->id,


### PR DESCRIPTION
## Summary
- Guard against missing playlist relations when grouping source playlists to avoid calling `map()` on null

## Testing
- `./vendor/bin/pest` *(fails: SQLSTATE[HY000]: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc33cf8bc8321a8b75899670e7e45