### PR TITLE
Skip auto-refresh for child playlists

### DIFF
--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -3,28 +3,13 @@
 namespace App\Filament\Resources;
 
 use App\Enums\Status;
-use App\Filament\Resources\PlaylistResource\Pages;
-use App\Filament\Resources\PlaylistResource\RelationManagers;
-use App\Models\Playlist;
-use App\Rules\CheckIfUrlOrLocalPath;
-use Carbon\Carbon;
-use Filament\Forms;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
-use Filament\Tables;
-use Filament\Tables\Columns\Column;
-use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use RyanChandler\FilamentProgressColumn\ProgressColumn;
 use App\Facades\PlaylistUrlFacade;
+use App\Filament\Resources\PlaylistResource\Pages;
 use App\Filament\Resources\PlaylistSyncStatusResource\Pages\CreatePlaylistSyncStatus;
 use App\Filament\Resources\PlaylistSyncStatusResource\Pages\EditPlaylistSyncStatus;
 use App\Filament\Resources\PlaylistSyncStatusResource\Pages\ListPlaylistSyncStatuses;
 use App\Filament\Resources\PlaylistSyncStatusResource\Pages\ViewPlaylistSyncStatus;
+use App\Jobs\SyncPlaylistChildren;
 use App\Livewire\EpgViewer;
 use App\Livewire\MediaFlowProxyUrl;
 use App\Livewire\PlaylistEpgUrl;
@@ -32,16 +17,28 @@ use App\Livewire\PlaylistInfo;
 use App\Livewire\PlaylistM3uUrl;
 use App\Livewire\XtreamApiInfo;
 use App\Models\Category;
+use App\Models\Playlist;
 use App\Models\SourceGroup;
+use App\Rules\CheckIfUrlOrLocalPath;
 use App\Services\EpgCacheService;
-use App\Jobs\SyncPlaylistChildren;
+use Carbon\Carbon;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Schema;
-use Filament\Actions;
+use RyanChandler\FilamentProgressColumn\ProgressColumn;
 
 class PlaylistResource extends Resource
 {
@@ -106,8 +103,8 @@ class PlaylistResource extends Resource
                 Tables\Columns\TextColumn::make('name')
                     ->searchable()
                     ->sortable()
-                    ->formatStateUsing(fn($state, ?Playlist $record) => $record?->parent_id ? '↳ '.$state : $state)
-                    ->extraAttributes(fn(?Playlist $record) => $record?->parent_id ? ['class' => 'pl-6'] : []),
+                    ->formatStateUsing(fn ($state, ?Playlist $record) => $record?->parent_id ? '↳ '.$state : $state)
+                    ->extraAttributes(fn (?Playlist $record) => $record?->parent_id ? ['class' => 'pl-6'] : []),
                 Tables\Columns\TextColumn::make('url')
                     ->label('Playlist URL')
                     ->wrap()
@@ -116,17 +113,15 @@ class PlaylistResource extends Resource
                 Tables\Columns\TextColumn::make('available_streams')
                     ->label('Streams')
                     ->toggleable()
-                    ->formatStateUsing(fn(int $state): string => $state === 0 ? '∞' : (string)$state)
+                    ->formatStateUsing(fn (int $state): string => $state === 0 ? '∞' : (string) $state)
                     ->tooltip('Total streams available for this playlist (∞ indicates no limit)')
-                    ->description(fn(?Playlist $record): string =>
-                        "Active: " . (int) ($record ? Redis::get("active_streams:{$record->id}") : 0))
+                    ->description(fn (?Playlist $record): string => 'Active: '.(int) ($record ? Redis::get("active_streams:{$record->id}") : 0))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('groups_count')
                     ->label('Groups')
                     ->counts('groups')
                     ->toggleable()
-                    ->sortable()
-                    ->hidden(fn(?Playlist $record): bool => $record?->parent_id !== null),
+                    ->sortable(),
                 // Tables\Columns\TextColumn::make('channels_count')
                 //     ->label('Channels')
                 //     ->counts('channels')
@@ -136,38 +131,35 @@ class PlaylistResource extends Resource
                 Tables\Columns\TextColumn::make('live_channels_count')
                     ->label('Live')
                     ->counts('live_channels')
-                    ->description(fn(?Playlist $record): string => "Enabled: {$record?->enabled_live_channels_count}")
+                    ->description(fn (?Playlist $record): string => "Enabled: {$record?->enabled_live_channels_count}")
                     ->toggleable()
-                    ->sortable()
-                    ->hidden(fn(?Playlist $record): bool => $record?->parent_id !== null),
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('vod_channels_count')
                     ->label('VOD')
                     ->counts('vod_channels')
-                    ->description(fn(?Playlist $record): string => "Enabled: {$record?->enabled_vod_channels_count}")
+                    ->description(fn (?Playlist $record): string => "Enabled: {$record?->enabled_vod_channels_count}")
                     ->toggleable()
-                    ->sortable()
-                    ->hidden(fn(?Playlist $record): bool => $record?->parent_id !== null),
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('series_count')
                     ->label('Series')
                     ->counts('series')
-                    ->description(fn(?Playlist $record): string => "Enabled: {$record?->enabled_series_count}")
+                    ->description(fn (?Playlist $record): string => "Enabled: {$record?->enabled_series_count}")
                     ->toggleable()
-                    ->sortable()
-                    ->hidden(fn(?Playlist $record): bool => $record?->parent_id !== null),
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('status')
                     ->sortable()
                     ->badge()
                     ->toggleable()
-                    ->color(fn(Status $state) => $state->getColor()),
+                    ->color(fn (Status $state) => $state->getColor()),
                 ProgressColumn::make('progress')
                     ->label('Channel Sync')
                     ->sortable()
-                    ->poll(fn($record) => $record->status === Status::Processing || $record->status === Status::Pending ? '3s' : null)
+                    ->poll(fn ($record) => $record->status === Status::Processing || $record->status === Status::Pending ? '3s' : null)
                     ->toggleable(),
                 ProgressColumn::make('series_progress')
                     ->label('Series Sync')
                     ->sortable()
-                    ->poll(fn($record) => $record->status === Status::Processing || $record->status === Status::Pending ? '3s' : null)
+                    ->poll(fn ($record) => $record->status === Status::Processing || $record->status === Status::Pending ? '3s' : null)
                     ->toggleable(),
                 Tables\Columns\ToggleColumn::make('enable_proxy')
                     ->label('Proxy')
@@ -178,6 +170,7 @@ class PlaylistResource extends Resource
                     ->label('Auto Sync')
                     ->toggleable()
                     ->tooltip('Toggle auto-sync status')
+                    ->disabled(fn (?Playlist $record) => $record?->parent_id !== null)
                     ->sortable(),
                 Tables\Columns\TextColumn::make('synced')
                     ->label('Last Synced')
@@ -186,11 +179,12 @@ class PlaylistResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('sync_interval')
                     ->label('Interval')
+                    ->formatStateUsing(fn ($state, ?Playlist $record) => $record?->parent_id ? '' : $state)
                     ->toggleable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('sync_time')
                     ->label('Sync Time')
-                    ->formatStateUsing(fn(string $state): string => gmdate('H:i:s', (int)$state))
+                    ->formatStateUsing(fn (string $state): string => gmdate('H:i:s', (int) $state))
                     ->toggleable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('exp_date')
@@ -200,11 +194,13 @@ class PlaylistResource extends Resource
                             try {
                                 if ($record->xtream_status['user_info']['exp_date'] ?? false) {
                                     $expires = Carbon::createFromTimestamp($record->xtream_status['user_info']['exp_date']);
+
                                     return $expires->toDayDateTimeString();
                                 }
                             } catch (\Exception $e) {
                             }
                         }
+
                         return 'N/A';
                     })
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -240,8 +236,8 @@ class PlaylistResource extends Resource
                                 ->duration(10000)
                                 ->send();
                         })
-                        ->disabled(fn($record): bool => $record->status === Status::Processing)
-                        ->hidden(fn($record): bool => $record->parent_id !== null)
+                        ->disabled(fn ($record): bool => $record->status === Status::Processing)
+                        ->hidden(fn ($record): bool => $record->parent_id !== null)
                         ->requiresConfirmation()
                         ->icon('heroicon-o-arrow-path')
                         ->modalIcon('heroicon-o-arrow-path')
@@ -265,8 +261,8 @@ class PlaylistResource extends Resource
                                 ->duration(10000)
                                 ->send();
                         })
-                        ->disabled(fn($record): bool => $record->status === Status::Processing)
-                        ->hidden(fn($record): bool => !$record->xtream || $record->parent_id !== null)
+                        ->disabled(fn ($record): bool => $record->status === Status::Processing)
+                        ->hidden(fn ($record): bool => ! $record->xtream || $record->parent_id !== null)
                         ->requiresConfirmation()
                         ->icon('heroicon-o-arrow-down-tray')
                         ->modalIcon('heroicon-o-arrow-down-tray')
@@ -290,8 +286,8 @@ class PlaylistResource extends Resource
                                 ->duration(10000)
                                 ->send();
                         })
-                        ->disabled(fn($record): bool => $record->status === Status::Processing)
-                        ->hidden(fn($record): bool => !$record->xtream || $record->parent_id !== null)
+                        ->disabled(fn ($record): bool => $record->status === Status::Processing)
+                        ->hidden(fn ($record): bool => ! $record->xtream || $record->parent_id !== null)
                         ->requiresConfirmation()
                         ->icon('heroicon-o-arrow-down-tray')
                         ->modalIcon('heroicon-o-arrow-down-tray')
@@ -300,13 +296,13 @@ class PlaylistResource extends Resource
                     Tables\Actions\Action::make('Download M3U')
                         ->label('Download M3U')
                         ->icon('heroicon-o-arrow-down-tray')
-                        ->url(fn($record) => PlaylistUrlFacade::getUrls($record)['m3u'])
+                        ->url(fn ($record) => PlaylistUrlFacade::getUrls($record)['m3u'])
                         ->openUrlInNewTab(),
                     EpgCacheService::getEpgTableAction(),
                     Tables\Actions\Action::make('HDHomeRun URL')
                         ->label('HDHomeRun URL')
                         ->icon('heroicon-o-arrow-top-right-on-square')
-                        ->url(fn($record) => PlaylistUrlFacade::getUrls($record)['hdhr'])
+                        ->url(fn ($record) => PlaylistUrlFacade::getUrls($record)['hdhr'])
                         ->openUrlInNewTab(),
                     Tables\Actions\Action::make('Duplicate')
                         ->label('Duplicate')
@@ -327,7 +323,7 @@ class PlaylistResource extends Resource
                                 ->duration(3000)
                                 ->send();
                         })
-                        ->hidden(fn($record) => $record->parent_id !== null)
+                        ->hidden(fn ($record) => $record->parent_id !== null)
                         ->requiresConfirmation()
                         ->icon('heroicon-o-document-duplicate')
                         ->modalIcon('heroicon-o-document-duplicate')
@@ -357,10 +353,10 @@ class PlaylistResource extends Resource
                         ->modalIcon('heroicon-o-link')
                         ->modalDescription('Duplicate playlist with sync now?')
                         ->modalSubmitActionLabel('Yes, duplicate with sync')
-                        ->hidden(fn($record) => $record->parent_id !== null),
+                        ->hidden(fn ($record) => $record->parent_id !== null),
                     Tables\Actions\Action::make('Unsync')
                         ->label('Unsync')
-                        ->action(fn($record) => $record->update(['parent_id' => null]))
+                        ->action(fn ($record) => $record->update(['parent_id' => null]))
                         ->after(function () {
                             Notification::make()
                                 ->success()
@@ -369,13 +365,13 @@ class PlaylistResource extends Resource
                         })
                         ->requiresConfirmation()
                         ->icon('heroicon-o-link-slash')
-                        ->hidden(fn($record) => $record->parent_id === null),
+                        ->hidden(fn ($record) => $record->parent_id === null),
                     Tables\Actions\Action::make('Sync Logs')
                         ->label('View Sync Logs')
                         ->color('gray')
                         ->icon('heroicon-m-arrows-right-left')
                         ->url(
-                            fn(Playlist $record): string => PlaylistResource::getUrl(
+                            fn (Playlist $record): string => PlaylistResource::getUrl(
                                 name: 'playlist-sync-statuses.index',
                                 parameters: [
                                     'parent' => $record->id,
@@ -413,7 +409,7 @@ class PlaylistResource extends Resource
                         ->label('Reset active count')
                         ->icon('heroicon-o-numbered-list')
                         ->color('warning')
-                        ->action(fn($record) => Redis::set("active_streams:{$record->id}", 0))->after(function () {
+                        ->action(fn ($record) => Redis::set("active_streams:{$record->id}", 0))->after(function () {
                             Notification::make()
                                 ->success()
                                 ->title('Active stream count reset')
@@ -439,7 +435,7 @@ class PlaylistResource extends Resource
                         ->modalIcon('heroicon-s-trash')
                         ->modalDescription('This action will permanently delete all series associated with the playlist. Proceed with caution.')
                         ->modalSubmitActionLabel('Purge now')
-                        ->hidden(fn($record): bool => !$record->xtream),
+                        ->hidden(fn ($record): bool => ! $record->xtream),
                     Tables\Actions\DeleteAction::make(),
                 ])->button()->hiddenLabel()->size('sm'),
                 Tables\Actions\EditAction::make()->button()->hiddenLabel()->size('sm'),
@@ -526,7 +522,7 @@ class PlaylistResource extends Resource
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ])->checkIfRecordIsSelectableUsing(
-                fn($record): bool => $record->status !== Status::Processing,
+                fn ($record): bool => $record->status !== Status::Processing,
             );
     }
 
@@ -548,9 +544,9 @@ class PlaylistResource extends Resource
 
             // Playlist Sync Statuses
             'playlist-sync-statuses.index' => ListPlaylistSyncStatuses::route('/{parent}/syncs'),
-            //'playlist-sync-statuses.create' => CreatePlaylistSyncStatus::route('/{parent}/syncs/create'),
+            // 'playlist-sync-statuses.create' => CreatePlaylistSyncStatus::route('/{parent}/syncs/create'),
             'playlist-sync-statuses.view' => ViewPlaylistSyncStatus::route('/{parent}/syncs/{record}'),
-            //'playlist-sync-statuses.edit' => EditPlaylistSyncStatus::route('/{parent}/syncs/{record}/edit'),
+            // 'playlist-sync-statuses.edit' => EditPlaylistSyncStatus::route('/{parent}/syncs/{record}/edit'),
         ];
     }
 
@@ -562,7 +558,7 @@ class PlaylistResource extends Resource
                 ->color('gray')
                 ->icon('heroicon-m-arrows-right-left')
                 ->url(
-                    fn(Playlist $record): string => PlaylistResource::getUrl(
+                    fn (Playlist $record): string => PlaylistResource::getUrl(
                         name: 'playlist-sync-statuses.index',
                         parameters: [
                             'parent' => $record->id,
@@ -588,8 +584,8 @@ class PlaylistResource extends Resource
                             ->duration(10000)
                             ->send();
                     })
-                    ->disabled(fn($record): bool => $record->status === Status::Processing)
-                    ->hidden(fn($record): bool => $record->parent_id !== null)
+                    ->disabled(fn ($record): bool => $record->status === Status::Processing)
+                    ->hidden(fn ($record): bool => $record->parent_id !== null)
                     ->requiresConfirmation()
                     ->icon('heroicon-o-arrow-path')
                     ->modalIcon('heroicon-o-arrow-path')
@@ -613,8 +609,8 @@ class PlaylistResource extends Resource
                             ->duration(10000)
                             ->send();
                     })
-                    ->disabled(fn($record): bool => $record->status === Status::Processing)
-                    ->hidden(fn($record): bool => !$record->xtream || $record->parent_id !== null)
+                    ->disabled(fn ($record): bool => $record->status === Status::Processing)
+                    ->hidden(fn ($record): bool => ! $record->xtream || $record->parent_id !== null)
                     ->requiresConfirmation()
                     ->icon('heroicon-o-arrow-down-tray')
                     ->modalIcon('heroicon-o-arrow-down-tray')
@@ -638,8 +634,8 @@ class PlaylistResource extends Resource
                             ->duration(10000)
                             ->send();
                     })
-                    ->disabled(fn($record): bool => $record->status === Status::Processing)
-                    ->hidden(fn($record): bool => !$record->xtream || $record->parent_id !== null)
+                    ->disabled(fn ($record): bool => $record->status === Status::Processing)
+                    ->hidden(fn ($record): bool => ! $record->xtream || $record->parent_id !== null)
                     ->requiresConfirmation()
                     ->icon('heroicon-o-arrow-down-tray')
                     ->modalIcon('heroicon-o-arrow-down-tray')
@@ -648,13 +644,13 @@ class PlaylistResource extends Resource
                 Actions\Action::make('Download M3U')
                     ->label('Download M3U')
                     ->icon('heroicon-o-arrow-down-tray')
-                    ->url(fn($record) => \App\Facades\PlaylistUrlFacade::getUrls($record)['m3u'])
+                    ->url(fn ($record) => \App\Facades\PlaylistUrlFacade::getUrls($record)['m3u'])
                     ->openUrlInNewTab(),
                 EpgCacheService::getEpgPlaylistAction(),
                 Actions\Action::make('HDHomeRun URL')
                     ->label('HDHomeRun URL')
                     ->icon('heroicon-o-arrow-top-right-on-square')
-                    ->url(fn($record) => \App\Facades\PlaylistUrlFacade::getUrls($record)['hdhr'])
+                    ->url(fn ($record) => \App\Facades\PlaylistUrlFacade::getUrls($record)['hdhr'])
                     ->openUrlInNewTab(),
                 Actions\Action::make('Duplicate')
                     ->label('Duplicate')
@@ -675,7 +671,7 @@ class PlaylistResource extends Resource
                             ->duration(3000)
                             ->send();
                     })
-                    ->hidden(fn($record) => $record->parent_id !== null)
+                    ->hidden(fn ($record) => $record->parent_id !== null)
                     ->requiresConfirmation()
                     ->icon('heroicon-o-document-duplicate')
                     ->modalIcon('heroicon-o-document-duplicate')
@@ -690,7 +686,7 @@ class PlaylistResource extends Resource
                             ->helperText('This will be the name of the duplicated playlist.'),
                     ])
                     ->action(function ($record, $data) {
-                            app('Illuminate\\Contracts\\Bus\\Dispatcher')
+                        app('Illuminate\\Contracts\\Bus\\Dispatcher')
                             ->dispatch(new \App\Jobs\DuplicatePlaylist($record, $data['name'], true));
                     })->after(function () {
                         Notification::make()
@@ -705,10 +701,10 @@ class PlaylistResource extends Resource
                     ->modalIcon('heroicon-o-link')
                     ->modalDescription('Duplicate playlist with sync now?')
                     ->modalSubmitActionLabel('Yes, duplicate with sync')
-                    ->hidden(fn($record) => $record->parent_id !== null),
+                    ->hidden(fn ($record) => $record->parent_id !== null),
                 Actions\Action::make('Unsync')
                     ->label('Unsync')
-                    ->action(fn($record) => $record->update(['parent_id' => null]))
+                    ->action(fn ($record) => $record->update(['parent_id' => null]))
                     ->after(function () {
                         Notification::make()
                             ->success()
@@ -717,7 +713,7 @@ class PlaylistResource extends Resource
                     })
                     ->requiresConfirmation()
                     ->icon('heroicon-o-link-slash')
-                    ->hidden(fn($record) => $record->parent_id === null),
+                    ->hidden(fn ($record) => $record->parent_id === null),
                 Actions\Action::make('reset')
                     ->label('Reset status')
                     ->icon('heroicon-o-arrow-uturn-left')
@@ -749,7 +745,7 @@ class PlaylistResource extends Resource
                     ->label('Reset active count')
                     ->icon('heroicon-o-numbered-list')
                     ->color('warning')
-                    ->action(fn($record) => Redis::set("active_streams:{$record->id}", 0))->after(function () {
+                    ->action(fn ($record) => Redis::set("active_streams:{$record->id}", 0))->after(function () {
                         Notification::make()
                             ->success()
                             ->title('Active stream count reset')
@@ -775,7 +771,8 @@ class PlaylistResource extends Resource
         ];
         if (PlaylistUrlFacade::mediaFlowProxyEnabled()) {
             $links[] = Infolists\Components\Livewire::make(MediaFlowProxyUrl::class);
-        };
+        }
+
         return $infolist
             ->schema([
                 Infolists\Components\Tabs::make()
@@ -792,7 +789,7 @@ class PlaylistResource extends Resource
                             ->schema([
                                 Infolists\Components\Section::make()
                                     ->columns(2)
-                                    ->schema($links)
+                                    ->schema($links),
                             ]),
                         Infolists\Components\Tabs\Tab::make('Xtream API')
                             ->icon('heroicon-m-bolt')
@@ -800,8 +797,8 @@ class PlaylistResource extends Resource
                                 Infolists\Components\Section::make()
                                     ->columns(1)
                                     ->schema([
-                                        Infolists\Components\Livewire::make(XtreamApiInfo::class)
-                                    ])
+                                        Infolists\Components\Livewire::make(XtreamApiInfo::class),
+                                    ]),
                             ]),
                     ])->contained(false),
                 Infolists\Components\Livewire::make(EpgViewer::class)
@@ -849,7 +846,7 @@ class PlaylistResource extends Resource
                             'heroicon-m-exclamation-triangle',
                             tooltip: 'Be careful changing this value as this will change the URLs for the Playlist, its EPG, and HDHR.'
                         )
-                        ->hidden(fn($get): bool => !$get('edit_uuid'))
+                        ->hidden(fn ($get): bool => ! $get('edit_uuid'))
                         ->required(),
                 ])->hiddenOn('create'),
         ];
@@ -881,7 +878,7 @@ class PlaylistResource extends Resource
                         ->url()
                         ->columnSpan(2)
                         ->required()
-                        ->hidden(fn(Get $get): bool => !$get('xtream')),
+                        ->hidden(fn (Get $get): bool => ! $get('xtream')),
                     Forms\Components\Grid::make()
                         ->columnSpanFull()
                         ->schema([
@@ -924,16 +921,16 @@ class PlaylistResource extends Resource
                                         ->inline(false)
                                         ->default(true),
                                 ]),
-                        ])->hidden(fn(Get $get): bool => !$get('xtream')),
+                        ])->hidden(fn (Get $get): bool => ! $get('xtream')),
                     Forms\Components\TextInput::make('url')
                         ->label('URL or Local file path')
                         ->columnSpan(2)
                         ->prefixIcon('heroicon-m-globe-alt')
                         ->helperText('Enter the URL of the playlist file. If this is a local file, you can enter a full or relative path. If changing URL, the playlist will be re-imported. Use with caution as this could lead to data loss if the new playlist differs from the old one.')
                         ->requiredWithout('uploads')
-                        ->rules([new CheckIfUrlOrLocalPath()])
+                        ->rules([new CheckIfUrlOrLocalPath])
                         ->maxLength(255)
-                        ->hidden(fn(Get $get): bool => !!$get('xtream')),
+                        ->hidden(fn (Get $get): bool => (bool) $get('xtream')),
                     Forms\Components\FileUpload::make('uploads')
                         ->label('File')
                         ->columnSpan(2)
@@ -942,7 +939,7 @@ class PlaylistResource extends Resource
                         ->helperText('Upload the playlist file. This will be used to import groups and channels.')
                         ->rules(['file'])
                         ->requiredWithout('url')
-                        ->hidden(fn(Get $get): bool => !!$get('xtream')),
+                        ->hidden(fn (Get $get): bool => (bool) $get('xtream')),
                 ]),
 
             Forms\Components\Grid::make()
@@ -961,13 +958,14 @@ class PlaylistResource extends Resource
                         ->onColor('danger')
                         ->inline(false)
                         ->default(false),
-                ])
+                ]),
         ];
 
         $schedulingFields = [
             Forms\Components\Grid::make()
                 ->columns(2)
                 ->columnSpanFull()
+                ->hidden(fn (Get $get, ?Playlist $record) => ($record?->parent_id ?? $get('parent_id')) !== null)
                 ->schema([
                     Forms\Components\Grid::make()
                         ->columns(3)
@@ -979,7 +977,8 @@ class PlaylistResource extends Resource
                                 ->live()
                                 ->columnSpan(2)
                                 ->inline(false)
-                                ->default(true),
+                                ->default(true)
+                                ->disabled(fn (?Playlist $record) => $record?->parent_id !== null),
                             Forms\Components\Select::make('sync_interval')
                                 ->label('Sync Every')
                                 ->helperText('Default is every 24hr if left empty.')
@@ -1003,7 +1002,7 @@ class PlaylistResource extends Resource
                                     '1 week' => '1 week',
                                     '2 weeks' => '2 weeks',
                                     '1 month' => '1 month',
-                                ])->hidden(fn(Get $get): bool => !$get('auto_sync')),
+                                ])->hidden(fn (Get $get): bool => ! $get('auto_sync')),
                             Forms\Components\Toggle::make('backup_before_sync')
                                 ->label('Backup Before Sync')
                                 ->helperText('When enabled, a backup will be created before syncing.')
@@ -1017,9 +1016,9 @@ class PlaylistResource extends Resource
                         ->suffix(config('app.timezone'))
                         ->native(false)
                         ->label('Last Synced')
-                        ->hidden(fn(Get $get, string $operation): bool => !$get('auto_sync') || $operation === 'create')
+                        ->hidden(fn (Get $get, string $operation): bool => ! $get('auto_sync') || $operation === 'create')
                         ->helperText('Playlist will be synced at the specified interval. Timestamp is automatically updated after each sync. Set to any time in the past (or future) and the next sync will run when the defined interval has passed since the time set.'),
-                ])
+                ]),
         ];
 
         $processingFields = [
@@ -1048,7 +1047,7 @@ class PlaylistResource extends Resource
                         ->live()
                         ->default(false)
                         ->helperText('When enabled, groups will be included based on regex pattern match instead of prefix.')
-                        ->hidden(fn(Get $get): bool => !$get('import_prefs.preprocess') || !$get('status')),
+                        ->hidden(fn (Get $get): bool => ! $get('import_prefs.preprocess') || ! $get('status')),
 
                     Forms\Components\Fieldset::make('Channel & VOD processing')
                         ->schema([
@@ -1059,12 +1058,11 @@ class PlaylistResource extends Resource
                                 ->multiple()
                                 ->helperText('NOTE: If the list is empty, sync the playlist and check again once complete.')
                                 ->options(
-                                    fn($record): array =>
-                                    SourceGroup::where('playlist_id', $record->id)
+                                    fn ($record): array => SourceGroup::where('playlist_id', $record->id)
                                         ->get()->pluck('name', 'name')->toArray()
                                 ),
                             Forms\Components\TagsInput::make('import_prefs.included_group_prefixes')
-                                ->label(fn(Get $get) => !$get('import_prefs.use_regex') ? 'Group prefixes to import' : 'Regex patterns to import')
+                                ->label(fn (Get $get) => ! $get('import_prefs.use_regex') ? 'Group prefixes to import' : 'Regex patterns to import')
                                 ->helperText('Press [tab] or [return] to add item.')
                                 ->columnSpan(1)
                                 ->suggestions([
@@ -1073,10 +1071,10 @@ class PlaylistResource extends Resource
                                     'CA -',
                                     '^(US|UK|CA)',
                                     'Sports.*HD$',
-                                    '\[.*\]'
+                                    '\[.*\]',
                                 ])
                                 ->splitKeys(['Tab', 'Return']),
-                        ])->hidden(fn(Get $get): bool => !$get('import_prefs.preprocess') || !$get('status')),
+                        ])->hidden(fn (Get $get): bool => ! $get('import_prefs.preprocess') || ! $get('status')),
 
                     Forms\Components\Fieldset::make('Series processing')
                         ->schema([
@@ -1087,12 +1085,11 @@ class PlaylistResource extends Resource
                                 ->multiple()
                                 ->helperText('NOTE: If the list is empty, sync the playlist and check again once complete.')
                                 ->options(
-                                    fn($record): array =>
-                                    Category::where('playlist_id', $record->id)
+                                    fn ($record): array => Category::where('playlist_id', $record->id)
                                         ->get()->pluck('name', 'name')->toArray()
                                 ),
                             Forms\Components\TagsInput::make('import_prefs.included_category_prefixes')
-                                ->label(fn(Get $get) => !$get('import_prefs.use_regex') ? 'Category prefixes to import' : 'Regex patterns to import')
+                                ->label(fn (Get $get) => ! $get('import_prefs.use_regex') ? 'Category prefixes to import' : 'Regex patterns to import')
                                 ->helperText('Press [tab] or [return] to add item.')
                                 ->columnSpan(1)
                                 ->suggestions([
@@ -1101,10 +1098,10 @@ class PlaylistResource extends Resource
                                     'CA -',
                                     '^(US|UK|CA)',
                                     'Sports.*HD$',
-                                    '\[.*\]'
+                                    '\[.*\]',
                                 ])
                                 ->splitKeys(['Tab', 'Return']),
-                        ])->hidden(fn(Get $get): bool => !$get('import_prefs.preprocess') || !$get('status')),
+                        ])->hidden(fn (Get $get): bool => ! $get('import_prefs.preprocess') || ! $get('status')),
 
                     Forms\Components\TagsInput::make('import_prefs.ignored_file_types')
                         ->label('Ignored file types')
@@ -1141,7 +1138,7 @@ class PlaylistResource extends Resource
                         )
                         ->default(false)
                         ->helperText('When enabled, series will be included in the M3U output. It is recommended to enable the "Auto-fetch series metadata" option when enabled.'),
-                ])->hidden(fn(Get $get): bool => !$get('xtream')),
+                ])->hidden(fn (Get $get): bool => ! $get('xtream')),
         ];
 
         $outputFields = [
@@ -1158,9 +1155,9 @@ class PlaylistResource extends Resource
                         ->inline(false)
                         ->live()
                         ->default(true)
-                        ->disabled(fn(Get $get): bool => config('dev.disable_sync_logs', false))
-                        ->hint(fn(Get $get): string => config('dev.disable_sync_logs', false) ? 'Sync logs disabled globally in settings' : '')
-                        ->hintIcon(fn(Get $get): string => config('dev.disable_sync_logs', false) ? 'heroicon-m-lock-closed' : '')
+                        ->disabled(fn (Get $get): bool => config('dev.disable_sync_logs', false))
+                        ->hint(fn (Get $get): string => config('dev.disable_sync_logs', false) ? 'Sync logs disabled globally in settings' : '')
+                        ->hintIcon(fn (Get $get): string => config('dev.disable_sync_logs', false) ? 'heroicon-m-lock-closed' : '')
                         ->helperText('Retain logs of playlist syncs. This is useful for debugging and tracking changes to the playlist. This can lead to increased sync time and storage usage depending on the size of the playlist.'),
                     Forms\Components\Toggle::make('auto_sort')
                         ->label('Automatically assign sort number based on playlist order')
@@ -1180,7 +1177,7 @@ class PlaylistResource extends Resource
                         ->columnSpan(1)
                         ->rules(['min:1'])
                         ->type('number')
-                        ->hidden(fn(Get $get): bool => !$get('auto_channel_increment'))
+                        ->hidden(fn (Get $get): bool => ! $get('auto_channel_increment'))
                         ->required(),
                 ]),
             Forms\Components\Section::make('Streaming Output')
@@ -1192,8 +1189,8 @@ class PlaylistResource extends Resource
                 ->schema([
                     Forms\Components\Toggle::make('enable_proxy')
                         ->label('Enable Proxy')
-                        ->hint(fn(Get $get): string => $get('enable_proxy') ? 'Proxied' : 'Not proxied')
-                        ->hintIcon(fn(Get $get): string => !$get('enable_proxy') ? 'heroicon-m-lock-open' : 'heroicon-m-lock-closed')
+                        ->hint(fn (Get $get): string => $get('enable_proxy') ? 'Proxied' : 'Not proxied')
+                        ->hintIcon(fn (Get $get): string => ! $get('enable_proxy') ? 'heroicon-m-lock-open' : 'heroicon-m-lock-closed')
                         ->live()
                         ->helperText('When enabled, all streams will be proxied through the application. This allows for better compatibility with various clients and enables features such as stream limiting and output format selection.')
                         ->inline(false)
@@ -1219,7 +1216,7 @@ class PlaylistResource extends Resource
                         ->type('number')
                         ->default(0) // Default to 0 streams (for unlimted)
                         ->required()
-                        ->hidden(fn(Get $get): bool => !$get('enable_proxy')),
+                        ->hidden(fn (Get $get): bool => ! $get('enable_proxy')),
                     Forms\Components\Select::make('proxy_options.output')
                         ->label('Proxy Output Format')
                         ->required()
@@ -1228,13 +1225,13 @@ class PlaylistResource extends Resource
                             'hls' => 'HLS (.m3u8)',
                         ])
                         ->default('ts')
-                        ->helperText(fn() => config('proxy.shared_streaming.enabled') ? '' : 'NOTE: Only HLS streaming supports multiple connections per stream. MPEG-TS creates a new stream for each connection.')
-                        ->hidden(fn(Get $get): bool => !$get('enable_proxy')),
+                        ->helperText(fn () => config('proxy.shared_streaming.enabled') ? '' : 'NOTE: Only HLS streaming supports multiple connections per stream. MPEG-TS creates a new stream for each connection.')
+                        ->hidden(fn (Get $get): bool => ! $get('enable_proxy')),
                     Forms\Components\TextInput::make('server_timezone')
                         ->label('Provider Timezone')
                         ->helperText('The portal/provider timezone (DST-aware). Needed to correctly use timeshift functionality when playlist proxy is enabled.')
                         ->placeholder('Etc/UTC')
-                        ->hidden(fn(Get $get): bool => !$get('enable_proxy')),
+                        ->hidden(fn (Get $get): bool => ! $get('enable_proxy')),
                 ]),
             Forms\Components\Section::make('EPG Output')
                 ->description('EPG output options')
@@ -1268,14 +1265,14 @@ class PlaylistResource extends Resource
                         ->inline(false)
                         ->default(false)
                         ->helperText('When enabled, the channel group will be assigned to the dummy EPG as a <category> tag.')
-                        ->hidden(fn(Get $get): bool => !$get('dummy_epg')),
+                        ->hidden(fn (Get $get): bool => ! $get('dummy_epg')),
                     Forms\Components\TextInput::make('dummy_epg_length')
                         ->label('Dummy program length (in minutes)')
                         ->columnSpan(1)
                         ->rules(['min:1'])
                         ->type('number')
                         ->default(120)
-                        ->hidden(fn(Get $get): bool => !$get('dummy_epg')),
+                        ->hidden(fn (Get $get): bool => ! $get('dummy_epg')),
                 ]),
         ];
 
@@ -1296,11 +1293,12 @@ class PlaylistResource extends Resource
             if ($section === 'Name') {
                 $section = 'General';
             }
-            if (!in_array($section, ['Processing', 'Output'])) {
+            if (! in_array($section, ['Processing', 'Output'])) {
                 // Wrap the fields in a section
                 $fields = [
                     Forms\Components\Section::make($section)
-                        ->schema($fields),
+                        ->schema($fields)
+                        ->hidden(fn (Get $get, ?Playlist $record) => $section === 'Scheduling' && (($record?->parent_id ?? $get('parent_id')) !== null)),
                 ];
 
                 // If general section, add AUTH management
@@ -1324,7 +1322,7 @@ class PlaylistResource extends Resource
                                             if ($record) {
                                                 $currentAuths = $record->playlistAuths()->get();
                                                 foreach ($currentAuths as $auth) {
-                                                    $options[$auth->id] = $auth->name . ' (currently assigned)';
+                                                    $options[$auth->id] = $auth->name.' (currently assigned)';
                                                 }
                                             }
 
@@ -1346,6 +1344,7 @@ class PlaylistResource extends Resource
                                             if ($record) {
                                                 return $record->playlistAuths()->pluck('playlist_auths.id')->toArray();
                                             }
+
                                             return [];
                                         })
                                         ->afterStateHydrated(function ($component, $state, $record) {
@@ -1360,7 +1359,9 @@ class PlaylistResource extends Resource
                                         )
                                         ->helperText('Simple authentication for playlist access.')
                                         ->afterStateUpdated(function ($state, $record) {
-                                            if (!$record) return;
+                                            if (! $record) {
+                                                return;
+                                            }
 
                                             $currentAuthIds = $record->playlistAuths()->pluck('playlist_auths.id')->toArray();
                                             $newAuthIds = $state ? (is_array($state) ? $state : [$state]) : [];
@@ -1386,11 +1387,12 @@ class PlaylistResource extends Resource
                                         ->dehydrated(false), // Don't save this field directly
                                 ]),
                         ]);
-                };
+                }
             }
 
             $tabs[] = Forms\Components\Tabs\Tab::make($section)
-                ->schema($fields);
+                ->schema($fields)
+                ->hidden(fn (Get $get, ?Playlist $record) => $section === 'Scheduling' && (($record?->parent_id ?? $get('parent_id')) !== null));
         }
 
         // Compose the form with tabs and sections
@@ -1413,7 +1415,8 @@ class PlaylistResource extends Resource
         $wizard = [];
         foreach (self::getFormSections(creating: true) as $step => $fields) {
             $wizard[] = Forms\Components\Wizard\Step::make($step)
-                ->schema($fields);
+                ->schema($fields)
+                ->hidden(fn (Get $get, ?Playlist $record) => $step === 'Scheduling' && (($record?->parent_id ?? $get('parent_id')) !== null));
 
             // Add auth after type step
             if ($step === 'Type') {
@@ -1450,7 +1453,7 @@ class PlaylistResource extends Resource
                             ->searchable()
                             ->placeholder('Select an auth to assign')
                             ->columnSpanFull()
-                            ->visible(fn(Forms\Get $get): bool => $get('auth_option') === 'existing'),
+                            ->visible(fn (Forms\Get $get): bool => $get('auth_option') === 'existing'),
 
                         // Create New Auth Fields
                         Forms\Components\Grid::make(2)
@@ -1476,10 +1479,11 @@ class PlaylistResource extends Resource
                                     ->required()
                                     ->columnSpan(1),
                             ])
-                            ->visible(fn(Forms\Get $get): bool => $get('auth_option') === 'create'),
+                            ->visible(fn (Forms\Get $get): bool => $get('auth_option') === 'create'),
                     ]);
             }
         }
+
         return $wizard;
     }
 }

--- a/app/Jobs/DuplicatePlaylist.php
+++ b/app/Jobs/DuplicatePlaylist.php
@@ -60,6 +60,7 @@ class DuplicatePlaylist implements ShouldQueue
             $newPlaylist->updated_at = $now;
             if ($this->withSync) {
                 $newPlaylist->parent_id = $playlist->id;
+                $newPlaylist->auto_sync = false;
             }
             $newPlaylist->saveQuietly(); // Don't fire model events to prevent auto sync
 
@@ -177,6 +178,7 @@ class DuplicatePlaylist implements ShouldQueue
                     logger()->info('DuplicatePlaylist: missing child channel for failover copy', [
                         'channel_id' => $channel->id,
                     ]);
+
                     continue;
                 }
 

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -6,7 +6,6 @@ use App\Enums\PlaylistChannelId;
 use App\Enums\Status;
 use App\Jobs\SyncPlaylistChildren;
 use App\Traits\ShortUrlTrait;
-use AshAllenDesign\ShortURL\Models\ShortURL;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -52,7 +51,7 @@ class Playlist extends Model
         'auto_fetch_series_metadata' => 'boolean',
         'parent_id' => 'integer',
         'status' => Status::class,
-        'id_channel_by' => PlaylistChannelId::class
+        'id_channel_by' => PlaylistChannelId::class,
     ];
 
     public function getFolderPathAttribute(): string
@@ -204,6 +203,12 @@ class Playlist extends Model
 
     protected static function booted()
     {
+        static::creating(function (Playlist $playlist) {
+            if ($playlist->parent_id !== null) {
+                $playlist->auto_sync = false;
+            }
+        });
+
         static::saved(function (Playlist $playlist) {
             if ($playlist->wasChanged('parent_id')) {
                 if ($original = $playlist->getOriginal('parent_id')) {


### PR DESCRIPTION
## Summary
- avoid scheduling child playlists in `app:refresh-playlist` command
- prevent manual refresh of child playlists to rely on post-parent chain
- hide scheduling controls for child playlists in Filament forms and wizards
- disable auto-sync toggle for child playlists and leave their interval display blank
- restore child playlist metrics in tables while keeping interval value empty
- remove obsolete child auto-sync test
- hide the Scheduling tab for child playlists and blank their interval column
- hide Scheduling step in setup wizard when playlist has a parent

## Testing
- `APP_ENV=testing BROADCAST_CONNECTION=log BROADCAST_DRIVER=log PUSHER_APP_KEY=dummy PUSHER_APP_SECRET=dummy PUSHER_APP_ID=dummy php artisan test tests/Unit/ExampleTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdaec98ae48321b737433b2c549247