### PR TITLE
Prevent null relation map errors in playlist bulk actions

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -7,6 +7,7 @@ use App\Models\Playlist;
 use Filament\Forms;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
+use Filament\Tables\Actions\Action as TableAction;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
@@ -91,7 +92,7 @@ trait HandlesSourcePlaylist
         $groups = [];
 
         $playlists
-            ->flatMap(fn ($playlist) => ($playlist->$relation ?? collect())
+            ->flatMap(fn ($playlist) => collect($playlist->$relation)
                 ->map(fn ($item) => [
                     'source_id' => $item->$sourceKey,
                     'playlist_id' => $playlist->id,
@@ -470,8 +471,8 @@ trait HandlesSourcePlaylist
         /** @var Tables\Actions\Action|Tables\Actions\BulkAction $action */
         $action = $actionClass::make('add')
             ->label('Add to Custom Playlist')
-            ->form(function ($records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData, $recordsResolver, $isBulk, $allowDrilldown): array {
-                $records = $isBulk ? $records : collect([$records]);
+            ->form(function (TableAction $action) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData, $recordsResolver, $isBulk, $allowDrilldown): array {
+                $records = $isBulk ? $action->getRecords() : collect([$action->getRecord()]);
                 if ($recordsResolver) {
                     $records = $recordsResolver($records);
                 }
@@ -514,8 +515,8 @@ trait HandlesSourcePlaylist
 
                 return $form;
             })
-            ->action(function ($records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData, $recordsResolver, $isBulk, $itemLabel, $allowDrilldown): void {
-                $records = $isBulk ? $records : collect([$records]);
+            ->action(function (TableAction $action, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData, $recordsResolver, $isBulk, $itemLabel, $allowDrilldown): void {
+                $records = $isBulk ? $action->getRecords() : collect([$action->getRecord()]);
                 if ($recordsResolver) {
                     $records = $recordsResolver($records);
                 }


### PR DESCRIPTION
## Summary
- Guard against missing playlist relations when grouping source playlists to avoid calling `map()` on null
- Retrieve selected records from the action instance instead of relying on an injected `$records` parameter, fixing unresolvable closure evaluations

## Testing
- `./vendor/bin/pest` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc33cf8bc8321a8b75899670e7e45