### PR TITLE
Prevent null relation map errors in playlist bulk actions

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -7,6 +7,8 @@ use App\Models\Playlist;
 use Filament\Forms;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
+use Filament\Tables\Actions\Action as TableAction;
+use Filament\Tables\Actions\BulkAction as TableBulkAction;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
@@ -60,7 +62,15 @@ trait HandlesSourcePlaylist
     protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
     {
         $recordPlaylistIds = $records->pluck('playlist_id')->unique();
+        // Use channel ID as a fallback when the source ID is missing
+        $recordSources = $records
+            ->map(fn ($record) => $record->$sourceKey ?? 'ch-' . $record->id)
+            ->unique();
         $recordSourceIds = $records->pluck($sourceKey)->filter()->unique();
+        $recordSourceNumericIds = $recordSources
+            ->filter(fn ($id) => is_string($id) && str_starts_with($id, 'ch-'))
+            ->map(fn ($id) => (int) substr($id, 3))
+            ->values();
 
         $parentIds = Playlist::whereIn('id', $recordPlaylistIds)
             ->pluck('parent_id')
@@ -78,11 +88,20 @@ trait HandlesSourcePlaylist
                     $query->orWhereIn('id', $parentIds);
                 }
             })
-            ->whereHas($relation, fn ($q) => $q->whereIn($sourceKey, $recordSourceIds))
+            ->whereHas($relation, function ($q) use ($sourceKey, $recordSourceIds, $recordSourceNumericIds) {
+                $q->whereIn($sourceKey, $recordSourceIds);
+                if ($recordSourceNumericIds->isNotEmpty()) {
+                    $q->orWhereIn('id', $recordSourceNumericIds);
+                }
+            })
             ->with([
-                $relation => fn ($q) => $q
-                    ->select('id', 'playlist_id', $sourceKey)
-                    ->whereIn($sourceKey, $recordSourceIds),
+                $relation => function ($q) use ($sourceKey, $recordSourceIds, $recordSourceNumericIds) {
+                    $q->select('id', 'playlist_id', $sourceKey)
+                        ->whereIn($sourceKey, $recordSourceIds);
+                    if ($recordSourceNumericIds->isNotEmpty()) {
+                        $q->orWhereIn('id', $recordSourceNumericIds);
+                    }
+                },
             ])
             ->get();
 
@@ -91,13 +110,13 @@ trait HandlesSourcePlaylist
         $groups = [];
 
         $playlists
-            ->flatMap(fn ($playlist) => ($playlist->$relation ?? collect())
+            ->flatMap(fn ($playlist) => collect($playlist->$relation)
                 ->map(fn ($item) => [
-                    'source_id' => $item->$sourceKey,
+                    'source' => $item->$sourceKey ?? 'ch-' . $item->id,
                     'playlist_id' => $playlist->id,
                 ]))
-            ->groupBy('source_id')
-            ->each(function ($group, $sourceId) use (&$groups, $playlistMap) {
+            ->groupBy('source')
+            ->each(function ($group, $source) use (&$groups, $playlistMap) {
                 $ids = $group->pluck('playlist_id')->unique();
 
                 if ($ids->count() <= 1) {
@@ -120,9 +139,9 @@ trait HandlesSourcePlaylist
                             'composite_keys' => [],
                         ];
 
-                        $groups[$pairKey]['source_ids'][] = $sourceId;
-                        $groups[$pairKey]['composite_keys'][] = $id.':'.$sourceId;
-                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id.':'.$sourceId;
+                        $groups[$pairKey]['source_ids'][] = $source;
+                        $groups[$pairKey]['composite_keys'][] = $id.':'.$source;
+                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id.':'.$source;
                     }
                 }
             });
@@ -137,8 +156,8 @@ trait HandlesSourcePlaylist
 
         // Store the selected record details under their respective group
         foreach ($records as $record) {
-            $sourceId = $record->$sourceKey;
-            $composite = $record->playlist_id.':'.$sourceId;
+            $source = $record->$sourceKey ?? 'ch-' . $record->id;
+            $composite = $record->playlist_id.':'.$source;
 
             if (! $sourceToGroup->has($composite)) {
                 continue;
@@ -150,7 +169,7 @@ trait HandlesSourcePlaylist
             $group['records'][$record->id] = [
                 'id' => $record->id,
                 'title' => $record->title ?? $record->name ?? '',
-                'source_id' => $sourceId,
+                'source_id' => $source,
                 'playlist_id' => $record->playlist_id,
             ];
             $duplicateGroups[$pairKey] = $group;
@@ -158,7 +177,7 @@ trait HandlesSourcePlaylist
 
         $needsSourcePlaylist = $duplicateGroups->isNotEmpty();
 
-        return [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup];
+        return [$duplicateGroups, $needsSourcePlaylist, $recordSources, $sourceToGroup];
     }
 
     /**
@@ -192,13 +211,14 @@ trait HandlesSourcePlaylist
                     $groupId = $groupEntry['group']->id;
                     foreach ($groupEntry['channels'] as $channel) {
                         $recordGroups[$channel->id] = $groupId;
-                        $compositeGroups[$channel->playlist_id.':'.$channel->$sourceKey] = $groupId;
+                        $token = $channel->$sourceKey ?? 'ch-' . $channel->id;
+                        $compositeGroups[$channel->playlist_id.':'.$token] = $groupId;
                     }
                 }
 
                 // Compute duplicate metadata once over the flattened records
                 $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
-                [$dupGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
+                [$dupGroups, $needsSourcePlaylist, $recordSources, $sourceToGroup] = $sourcePlaylistData;
 
                 // Re-map duplicate groups back to their parent groups with unique keys
                 $groupedDuplicates = [];
@@ -226,7 +246,7 @@ trait HandlesSourcePlaylist
                 $sourcePlaylistData = [
                     collect($groupedDuplicates),
                     $needsSourcePlaylist,
-                    $recordSourceIds,
+                    $recordSources,
                     $globalSourceToGroup,
                 ];
             } else {
@@ -355,7 +375,7 @@ trait HandlesSourcePlaylist
             return $records;
         }
 
-        return $records->flatMap(fn ($group) => $group['channels']);
+        return $records->flatMap(fn ($group) => collect($group['channels'] ?? []));
     }
 
     /**
@@ -389,7 +409,7 @@ trait HandlesSourcePlaylist
             $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
         }
 
-        [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
+        [$duplicateGroups, $needsSourcePlaylist, $recordSources, $sourceToGroup] = $sourcePlaylistData;
 
         if ($needsSourcePlaylist) {
             $selected = collect($data['source_playlists'] ?? []);
@@ -412,25 +432,39 @@ trait HandlesSourcePlaylist
                 $itemSelected->flatMap(fn ($items) => collect($items)->filter()->values())
             )->unique();
 
+            $recordSourceNumericIds = $recordSources
+                ->filter(fn ($id) => is_string($id) && str_starts_with($id, 'ch-'))
+                ->map(fn ($id) => (int) substr($id, 3))
+                ->values();
+
             $sourceMaps = $modelClass::query()
                 ->whereIn('playlist_id', $playlistIds)
-                ->whereIn($sourceKey, $recordSourceIds)
+                ->where(function ($q) use ($sourceKey, $recordSources, $recordSourceNumericIds) {
+                    $q->whereIn($sourceKey, $recordSources);
+                    if ($recordSourceNumericIds->isNotEmpty()) {
+                        $q->orWhereIn('id', $recordSourceNumericIds);
+                    }
+                })
                 ->select('id', 'playlist_id', $sourceKey)
                 ->get()
+                ->map(function ($item) use ($sourceKey) {
+                    $item->composite_source = $item->$sourceKey ?? 'ch-' . $item->id;
+                    return $item;
+                })
                 ->groupBy('playlist_id')
-                ->map->keyBy($sourceKey);
+                ->map(fn ($group) => $group->keyBy('composite_source'));
 
             $records = $records->map(function ($record) use ($selected, $itemSelected, $sourceMaps, $sourceToGroup, $sourceKey) {
-                $sourceId = $record->$sourceKey;
-                $composite = $record->playlist_id.':'.$sourceId;
+                $source = $record->$sourceKey ?? 'ch-' . $record->id;
+                $composite = $record->playlist_id.':'.$source;
 
                 if ($sourceToGroup->has($composite)) {
                     $pairKey = $sourceToGroup[$composite];
                     $override = $itemSelected[$pairKey][$record->id] ?? null;
                     $playlistId = $override ?: ($selected[$pairKey] ?? null);
 
-                    return $playlistId && isset($sourceMaps[$playlistId][$sourceId])
-                        ? $sourceMaps[$playlistId][$sourceId]
+                    return $playlistId && isset($sourceMaps[$playlistId][$source])
+                        ? $sourceMaps[$playlistId][$source]
                         : $record;
                 }
 
@@ -470,8 +504,8 @@ trait HandlesSourcePlaylist
         /** @var Tables\Actions\Action|Tables\Actions\BulkAction $action */
         $action = $actionClass::make('add')
             ->label('Add to Custom Playlist')
-            ->form(function ($records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData, $recordsResolver, $isBulk, $allowDrilldown): array {
-                $records = $isBulk ? $records : collect([$records]);
+            ->form(function (TableAction|TableBulkAction $action) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData, $recordsResolver, $isBulk, $allowDrilldown): array {
+                $records = $isBulk ? $action->getRecords() : collect([$action->getRecord()]);
                 if ($recordsResolver) {
                     $records = $recordsResolver($records);
                 }
@@ -514,8 +548,8 @@ trait HandlesSourcePlaylist
 
                 return $form;
             })
-            ->action(function ($records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData, $recordsResolver, $isBulk, $itemLabel, $allowDrilldown): void {
-                $records = $isBulk ? $records : collect([$records]);
+            ->action(function (TableAction|TableBulkAction $action, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData, $recordsResolver, $isBulk, $itemLabel, $allowDrilldown): void {
+                $records = $isBulk ? $action->getRecords() : collect([$action->getRecord()]);
                 if ($recordsResolver) {
                     $records = $recordsResolver($records);
                 }

--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -151,7 +151,6 @@ class GroupResource extends Resource
                             'group'    => $group,
                             'channels' => $group->channels()
                                 ->select('id', 'playlist_id', 'source_id', 'title')
-                                ->whereNotNull('source_id')
                                 ->get(),
                         ])
                     ),
@@ -244,7 +243,6 @@ class GroupResource extends Resource
                             'group'    => $group,
                             'channels' => $group->channels()
                                 ->select('id', 'playlist_id', 'source_id', 'title')
-                                ->whereNotNull('source_id')
                                 ->get(),
                         ])
                     ),

--- a/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
+++ b/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
@@ -32,7 +32,6 @@ class ViewGroup extends ViewRecord
                     'Custom Group',
                     fn ($records) => $records->first()->channels()
                         ->select('id', 'playlist_id', 'source_id', 'title')
-                        ->whereNotNull('source_id')
                         ->get(),
                     true,
                     Actions\Action::class


### PR DESCRIPTION
## Summary
- Guard against missing playlist relations when grouping source playlists to avoid calling `map()` on null
- Retrieve selected records from the action instance instead of relying on an injected `$records` parameter, fixing unresolvable closure evaluations
- Flatten grouped records with an empty collection when channel lists are missing
- Accept both table and bulk action instances when constructing custom playlist actions to prevent type errors
- Detect duplicate parent/child playlist entries even when a channel lacks a source ID by falling back to its own ID, ensuring source playlist selection is presented
- Include group channels without source IDs in custom playlist actions, allowing fallback logic to apply to groups as well

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc33cf8bc8321a8b75899670e7e45