### PR TITLE
Prompt for source playlist when adding to custom playlists

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace App\Filament\BulkActions;
+
+use App\Models\CustomPlaylist;
+use App\Models\Playlist;
+use Filament\Forms;
+use Filament\Forms\Components\Actions;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
+use Filament\Notifications\Notification;
+use Filament\Tables;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Provides helpers for bulk actions that need to resolve the correct
+ * source playlist when a record exists in both a parent playlist and one
+ * or more of its children.
+ *
+ * Example usage:
+ *
+ * ```php
+ * use App\Filament\BulkActions\HandlesSourcePlaylist;
+ *
+ * class ChannelResource extends Resource
+ * {
+ *     use HandlesSourcePlaylist;
+ *
+ *     public static function getTableBulkActions(): array
+ *     {
+ *         return [
+ *             self::addToCustomPlaylistBulkAction(
+ *                 \App\Models\Channel::class,
+ *                 'channels',
+ *                 'source_id',
+ *                 'channel',
+ *                 'channel'
+ *             ),
+ *         ];
+ *     }
+ * }
+ * ```
+ */
+trait HandlesSourcePlaylist
+{
+    /**
+     * Build duplicate playlist metadata for the given records.
+     *
+     * @param Collection $records   Selected records from the bulk action.
+     * @param string     $relation  Relationship name used to query playlist items (channels, series, etc.).
+     * @param string     $sourceKey Source identifier column on the related model.
+     * @return array{0: Collection, 1: bool, 2: Collection, 3: Collection} Tuple containing
+     *                                             duplicate groups, whether a source playlist is
+     *                                             needed, the source IDs of the records, and a
+     *                                             map of composite playlist/source keys to their
+     *                                             parent-child group key.
+    */
+    protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
+    {
+        $recordPlaylistIds = $records->pluck('playlist_id')->unique();
+        $recordSourceIds   = $records->pluck($sourceKey)->unique();
+
+        $parentIds = Playlist::whereIn('id', $recordPlaylistIds)
+            ->pluck('parent_id')
+            ->filter()
+            ->unique()
+            ->all();
+
+        $playlists = Playlist::where('user_id', auth()->id())
+            ->select('id', 'parent_id', 'name')
+            ->where(function ($query) use ($recordPlaylistIds, $parentIds) {
+                $query->whereIn('id', $recordPlaylistIds)
+                    ->orWhereIn('parent_id', $recordPlaylistIds);
+
+                if (! empty($parentIds)) {
+                    $query->orWhereIn('id', $parentIds)
+                        ->orWhereIn('parent_id', $parentIds);
+                }
+            })
+            ->whereHas($relation, fn ($q) => $q->whereIn($sourceKey, $recordSourceIds))
+            ->with([
+                $relation => fn ($q) => $q
+                    ->select('id', 'playlist_id', $sourceKey)
+                    ->whereIn($sourceKey, $recordSourceIds),
+            ])
+            ->get();
+
+        $playlistMap = $playlists->keyBy('id');
+
+        $groups = [];
+
+        $playlists
+            ->flatMap(fn ($playlist) => ($playlist->$relation ?? collect())->map(fn ($item) => [
+                'source_id'   => $item->$sourceKey,
+                'playlist_id' => $playlist->id,
+            ]))
+            ->groupBy('source_id')
+            ->each(function ($group, $sourceId) use (&$groups, $playlistMap) {
+                $ids = $group->pluck('playlist_id')->unique();
+
+                if ($ids->count() <= 1) {
+                    return;
+                }
+
+                foreach ($ids as $id) {
+                    $playlist = $playlistMap[$id];
+
+                    if ($playlist->parent_id && $ids->contains($playlist->parent_id)) {
+                        $pairKey = $playlist->parent_id . '-' . $id;
+
+                        $groups[$pairKey] ??= [
+                            'parent_id'     => $playlist->parent_id,
+                            'child_id'      => $id,
+                            'playlists'     => $playlistMap
+                                ->only([$playlist->parent_id, $id])
+                                ->map->name,
+                            'source_ids'    => [],
+                            'composite_keys'=> [],
+                        ];
+
+                        $groups[$pairKey]['source_ids'][]     = $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $id . ':' . $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id . ':' . $sourceId;
+                    }
+                }
+            });
+
+        $duplicateGroups = collect($groups);
+
+        // Map composite playlist & source IDs to their parent-child pair
+        $sourceToGroup = $duplicateGroups
+            ->flatMap(fn ($group, $pairKey) => collect($group['composite_keys'])
+                ->unique()
+                ->mapWithKeys(fn ($key) => [$key => $pairKey]));
+
+        // Store the selected record details under their respective group
+        foreach ($records as $record) {
+            $sourceId  = $record->$sourceKey;
+            $composite = $record->playlist_id . ':' . $sourceId;
+
+            if (! $sourceToGroup->has($composite)) {
+                continue;
+            }
+
+            $pairKey = $sourceToGroup[$composite];
+
+            $group = $duplicateGroups[$pairKey];
+            $group['records'][$record->id] = [
+                'id'          => $record->id,
+                'title'       => $record->title ?? $record->name ?? '',
+                'source_id'   => $sourceId,
+                'playlist_id' => $record->playlist_id,
+            ];
+            $duplicateGroups[$pairKey] = $group;
+        }
+
+        $needsSourcePlaylist = $duplicateGroups->isNotEmpty();
+
+        return [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup];
+    }
+
+    /**
+     * Build form fields allowing users to choose the source playlist for
+     * duplicate parent/child groups and optionally override individual
+     * records within those groups.
+     *
+     * @param Collection      $records            Records selected in the bulk action.
+     * @param string          $relation           Relationship name used to fetch playlist items.
+     * @param string          $sourceKey          Column containing the source ID on the related model.
+     * @param string          $itemLabel          Human-readable label for the record type (channel, series, etc.).
+     * @param array|null      $sourcePlaylistData Cached metadata returned from {@see getSourcePlaylistData}.
+     *                                           Passed by reference so callers can reuse the computed data.
+     * @return array                             Array of Filament form components for inclusion in the bulk action.
+     */
+    protected static function buildSourcePlaylistForm(
+        Collection $records,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        ?array &$sourcePlaylistData = null
+    ): array {
+        if ($sourcePlaylistData === null) {
+            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+        }
+
+        [$duplicateGroups, $needsSourcePlaylist] = $sourcePlaylistData;
+
+        if (! $needsSourcePlaylist) {
+            return [];
+        }
+
+        $fields = [];
+
+        foreach ($duplicateGroups as $pairKey => $group) {
+            $parentName = $group['playlists'][$group['parent_id']];
+            $childName  = $group['playlists'][$group['child_id']];
+
+            $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
+                ->schema([
+                    Forms\Components\Select::make("source_playlists.{$pairKey}")
+                        ->label('Use items from:')
+                        ->options($group['playlists']->toArray())
+                        ->required()
+                        ->searchable(),
+                    Actions::make([
+                        Action::make("view_affected_{$pairKey}")
+                            ->label('View affected items')
+                            ->modalHeading("Items in {$parentName} ↔ {$childName}")
+                            ->statePath("source_playlists_items.{$pairKey}")
+                            ->form(
+                                collect($group['records'] ?? [])->map(fn ($record) =>
+                                    Forms\Components\Select::make((string) $record['id'])
+                                        ->label($record['title'])
+                                        ->options($group['playlists']->toArray())
+                                        ->placeholder('Use group selection')
+                                        ->searchable()
+                                )->toArray()
+                            ),
+                    ]),
+                ]);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Resolve each selected record to the appropriate source playlist entry
+     * based on the user's selections.
+     *
+     * Performs validation to ensure every duplicate parent/child group has a
+     * source playlist chosen, and replaces records with their counterpart from
+     * the selected source playlist.
+     *
+     * @param Collection $records           Records originally selected in the bulk action.
+     * @param array      $data              Form data submitted by the user.
+     * @param string     $relation          Relationship name used to fetch playlist items.
+     * @param string     $sourceKey         Source identifier column on the related model.
+     * @param string     $modelClass        Fully qualified model class name for the records.
+     * @param array|null $sourcePlaylistData Cached metadata from {@see getSourcePlaylistData}.
+     *                                       Passed by reference to avoid recomputation.
+     * @return Collection                    Collection of records mapped to their chosen source playlist.
+     * @throws ValidationException           If any duplicate group lacks a source selection.
+     */
+    protected static function mapRecordsToSourcePlaylist(
+        Collection $records,
+        array $data,
+        string $relation,
+        string $sourceKey,
+        string $modelClass,
+        ?array $sourcePlaylistData = null
+    ): Collection {
+        if ($sourcePlaylistData === null) {
+            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+        }
+
+        [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
+
+        if ($needsSourcePlaylist) {
+            $selected     = collect($data['source_playlists'] ?? []);
+            $itemSelected = collect($data['source_playlists_items'] ?? []);
+
+            foreach ($duplicateGroups as $pairKey => $group) {
+                $bulk   = $selected[$pairKey] ?? null;
+                $items  = collect($itemSelected[$pairKey] ?? [])->filter();
+                $count  = count($group['records'] ?? []);
+
+                if (! $bulk && $items->count() !== $count) {
+                    throw ValidationException::withMessages([
+                        'source_playlists' => 'Please select a source playlist for each duplicated group.',
+                    ]);
+                }
+            }
+
+            $playlistIds = $selected->filter()->values();
+            $playlistIds = $playlistIds->merge(
+                $itemSelected->flatMap(fn ($items) => collect($items)->filter()->values())
+            )->unique();
+
+            $sourceMaps = $modelClass::query()
+                ->whereIn('playlist_id', $playlistIds)
+                ->whereIn($sourceKey, $recordSourceIds)
+                ->select('id', 'playlist_id', $sourceKey)
+                ->get()
+                ->groupBy('playlist_id')
+                ->map->keyBy($sourceKey);
+
+            $records = $records->map(function ($record) use ($selected, $itemSelected, $sourceMaps, $sourceToGroup, $sourceKey) {
+                $sourceId  = $record->$sourceKey;
+                $composite = $record->playlist_id . ':' . $sourceId;
+
+                if ($sourceToGroup->has($composite)) {
+                    $pairKey    = $sourceToGroup[$composite];
+                    $override   = $itemSelected[$pairKey][$record->id] ?? null;
+                    $playlistId = $override ?: ($selected[$pairKey] ?? null);
+
+                    return $playlistId && isset($sourceMaps[$playlistId][$sourceId])
+                        ? $sourceMaps[$playlistId][$sourceId]
+                        : $record;
+                }
+
+                return $record;
+            });
+        }
+
+        return $records;
+    }
+
+    /**
+     * Construct a Filament bulk action that adds the selected records to a
+     * custom playlist, including optional source playlist disambiguation.
+     *
+     * @param string $modelClass    Fully qualified model class for the records.
+     * @param string $relation      Relationship name used by the custom playlist (channels, series, vods).
+     * @param string $sourceKey     Column containing the source ID on the related model.
+     * @param string $itemLabel     Human-readable label for the record type.
+     * @param string $tagType       Tag type used when assigning categories/groups.
+     * @param string $categoryLabel Label displayed for the category select.
+     * @return Tables\Actions\BulkAction Configured bulk action ready to attach to a Filament table.
+     */
+    protected static function buildAddToCustomPlaylistAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group'
+    ): Tables\Actions\BulkAction {
+        $sourcePlaylistData = null;
+
+        return Tables\Actions\BulkAction::make('add')
+            ->label('Add to Custom Playlist')
+            ->form(function (Collection $records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData): array {
+                $form = [
+                    Forms\Components\Select::make('playlist')
+                        ->required()
+                        ->live()
+                        ->label('Custom Playlist')
+                        ->helperText("Select the custom playlist you would like to add the selected {$itemLabel} to.")
+                        ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
+                        ->afterStateUpdated(fn (Set $set, $state) => $state ? $set('category', null) : null)
+                        ->searchable(),
+                    Forms\Components\Select::make('category')
+                        ->label($categoryLabel)
+                        ->disabled(fn (Get $get) => ! $get('playlist'))
+                        ->helperText(fn (Get $get) => ! $get('playlist')
+                            ? 'Select a custom playlist first.'
+                            : 'Select the ' . ($categoryLabel === 'Custom Group' ? 'group' : 'category') .
+                                ' you would like to assign to the selected ' . $itemLabel . ' to.')
+                        ->options(function ($get) use ($tagType) {
+                            $customList = CustomPlaylist::find($get('playlist'));
+                            return $customList ? $customList->tags()
+                                ->where('type', $customList->uuid . $tagType)
+                                ->get()
+                                ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
+                                ->toArray() : [];
+                        })
+                        ->searchable(),
+                ];
+
+                $form = array_merge(
+                    $form,
+                    self::buildSourcePlaylistForm($records, $relation, $sourceKey, $itemLabel, $sourcePlaylistData)
+                );
+
+                return $form;
+            })
+            ->action(function (Collection $records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData): void {
+                $records = self::mapRecordsToSourcePlaylist($records, $data, $relation, $sourceKey, $modelClass, $sourcePlaylistData);
+
+                $playlist = CustomPlaylist::findOrFail($data['playlist']);
+                $playlist->$relation()->syncWithoutDetaching($records->pluck('id'));
+                if ($data['category']) {
+                    $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
+                }
+            })
+            ->after(function () use ($itemLabel) {
+                Notification::make()
+                    ->success()
+                    ->title(ucfirst($itemLabel) . ' added to custom playlist')
+                    ->body("The selected {$itemLabel} have been added to the chosen custom playlist.")
+                    ->send();
+            })
+            ->deselectRecordsAfterCompletion()
+            ->requiresConfirmation()
+            ->icon('heroicon-o-play')
+            ->modalIcon('heroicon-o-play')
+            ->modalDescription("Add the selected {$itemLabel} to the chosen custom playlist.")
+            ->modalSubmitActionLabel('Add now');
+    }
+
+    public static function addToCustomPlaylistBulkAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group'
+    ): Tables\Actions\BulkAction {
+        return self::buildAddToCustomPlaylistAction($modelClass, $relation, $sourceKey, $itemLabel, $tagType, $categoryLabel);
+    }
+}

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -6,7 +6,8 @@ use App\Filament\Resources\CategoryResource\Pages;
 use App\Filament\Resources\CategoryResource\RelationManagers;
 use App\Models\Category;
 use App\Models\CustomPlaylist;
-use App\Jobs\SyncPlaylistChildren;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
+use App\Filament\BulkActions\HandlesSourcePlaylist as HandlesSourcePlaylistTrait;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -22,6 +23,8 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class CategoryResource extends Resource
 {
+    use HandlesSourcePlaylistTrait;
+
     protected static ?string $model = Category::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -176,7 +179,7 @@ class CategoryResource extends Resource
                             $record->series()->update([
                                 'category_id' => $category->id,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            SyncPlaylistChildrenJob::debounce($record->playlist, []);
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -238,7 +241,7 @@ class CategoryResource extends Resource
                         ->label('Enable selected')
                         ->action(function ($record): void {
                             $record->series()->update(['enabled' => true]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            SyncPlaylistChildrenJob::debounce($record->playlist, []);
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -257,7 +260,7 @@ class CategoryResource extends Resource
                         ->label('Disable selected')
                         ->action(function ($record): void {
                             $record->series()->update(['enabled' => false]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            SyncPlaylistChildrenJob::debounce($record->playlist, []);
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -365,7 +368,7 @@ class CategoryResource extends Resource
                                 $record->series()->update([
                                     'category_id' => $category->id,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                SyncPlaylistChildrenJob::debounce($record->playlist, []);
                             }
                         })->after(function () {
                             Notification::make()
@@ -433,7 +436,7 @@ class CategoryResource extends Resource
                         ->action(function (Collection $records): void {
                             foreach ($records as $record) {
                                 $record->series()->update(['enabled' => true]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                SyncPlaylistChildrenJob::debounce($record->playlist, []);
                             }
                         })->after(function () {
                             Notification::make()
@@ -454,7 +457,7 @@ class CategoryResource extends Resource
                         ->action(function (Collection $records): void {
                             foreach ($records as $record) {
                                 $record->series()->update(['enabled' => false]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                SyncPlaylistChildrenJob::debounce($record->playlist, []);
                             }
                         })->after(function () {
                             Notification::make()

--- a/app/Filament/Resources/CategoryResource/Pages/ViewCategory.php
+++ b/app/Filament/Resources/CategoryResource/Pages/ViewCategory.php
@@ -5,7 +5,8 @@ namespace App\Filament\Resources\CategoryResource\Pages;
 use App\Filament\Resources\CategoryResource;
 use App\Models\CustomPlaylist;
 use App\Models\Category;
-use App\Jobs\SyncPlaylistChildren;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
+use App\Filament\BulkActions\HandlesSourcePlaylist as HandlesSourcePlaylistTrait;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
@@ -14,6 +15,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewCategory extends ViewRecord
 {
+    use HandlesSourcePlaylistTrait;
+
     protected static string $resource = CategoryResource::class;
 
     protected function getHeaderActions(): array
@@ -52,7 +55,7 @@ class ViewCategory extends ViewRecord
                     ->action(function ($record, array $data): void {
                         $playlist = CustomPlaylist::findOrFail($data['playlist']);
                         $playlist->series()->syncWithoutDetaching($record->series()->pluck('id'));
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function () {
                         Notification::make()
                             ->success()
@@ -81,7 +84,7 @@ class ViewCategory extends ViewRecord
                         $record->series()->update([
                             'category_id' => $category->id,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function () {
                         Notification::make()
                             ->success()
@@ -143,7 +146,7 @@ class ViewCategory extends ViewRecord
                     ->label('Enable category series')
                     ->action(function ($record): void {
                         $record->series()->update(['enabled' => true]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
                         Notification::make()
@@ -162,7 +165,7 @@ class ViewCategory extends ViewRecord
                     ->label('Disable category series')
                     ->action(function ($record): void {
                         $record->series()->update(['enabled' => false]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
                         Notification::make()

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -14,6 +14,8 @@ use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
+use App\Filament\BulkActions\HandlesSourcePlaylist as HandlesSourcePlaylistTrait;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -30,9 +32,11 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class ChannelResource extends Resource
 {
+    use HandlesSourcePlaylistTrait;
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -359,55 +363,8 @@ class ChannelResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Channel::class, 'channels', 'source_id', 'channel(s)', '')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([
@@ -439,6 +396,7 @@ class ChannelResource extends Resource
                                 'group_id' => $group->id,
                             ]);
                         }
+                        SyncPlaylistChildrenJob::debounce($group->playlist, []);
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -115,6 +115,11 @@ class ChannelsRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -123,7 +128,7 @@ class ChannelsRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent'])
                     ->withCount(['failovers'])
                     ->where('is_vod', false); // Only show live channels
             })

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -105,6 +105,11 @@ class SeriesRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 6, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -112,6 +117,7 @@ class SeriesRelationManager extends RelationManager
             ->filtersTriggerAction(function ($action) {
                 return $action->button()->label('Filters');
             })
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('playlist.parent'))
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
             ->columns($defaultColumns)

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
@@ -115,6 +115,11 @@ class VodRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -123,7 +128,7 @@ class VodRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent'])
                     ->withCount(['failovers'])
                     ->where('is_vod', true); // Only show VOD content
             })

--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -7,7 +7,8 @@ use App\Filament\Resources\GroupResource\RelationManagers;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\Playlist;
-use App\Jobs\SyncPlaylistChildren;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
+use App\Filament\BulkActions\HandlesSourcePlaylist as HandlesSourcePlaylistTrait;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -23,6 +24,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class GroupResource extends Resource
 {
+    use HandlesSourcePlaylistTrait;
     protected static ?string $model = Group::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -201,7 +203,7 @@ class GroupResource extends Resource
                                 'group' => $group->name,
                                 'group_id' => $group->id,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            SyncPlaylistChildrenJob::debounce($record->playlist, []);
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -221,7 +223,7 @@ class GroupResource extends Resource
                             $record->channels()->update([
                                 'enabled' => true,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            SyncPlaylistChildrenJob::debounce($record->playlist, []);
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -241,7 +243,7 @@ class GroupResource extends Resource
                             $record->channels()->update([
                                 'enabled' => false,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            SyncPlaylistChildrenJob::debounce($record->playlist, []);
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -352,7 +354,7 @@ class GroupResource extends Resource
                                     'group' => $group->name,
                                     'group_id' => $group->id,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                SyncPlaylistChildrenJob::debounce($record->playlist, []);
                             }
                         })->after(function () {
                             Notification::make()
@@ -373,7 +375,7 @@ class GroupResource extends Resource
                                 $record->channels()->update([
                                     'enabled' => true,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                SyncPlaylistChildrenJob::debounce($record->playlist, []);
                             }
                         })->after(function () {
                             Notification::make()
@@ -396,7 +398,7 @@ class GroupResource extends Resource
                                 $record->channels()->update([
                                     'enabled' => false,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                SyncPlaylistChildrenJob::debounce($record->playlist, []);
                             }
                         })->after(function () {
                             Notification::make()

--- a/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
+++ b/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
@@ -5,7 +5,8 @@ namespace App\Filament\Resources\GroupResource\Pages;
 use App\Filament\Resources\GroupResource;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
-use App\Jobs\SyncPlaylistChildren;
+use App\Filament\BulkActions\HandlesSourcePlaylist as HandlesSourcePlaylistTrait;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
@@ -14,6 +15,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewGroup extends ViewRecord
 {
+    use HandlesSourcePlaylistTrait;
+
     protected static string $resource = GroupResource::class;
 
     protected function getHeaderActions(): array
@@ -55,7 +58,7 @@ class ViewGroup extends ViewRecord
                         if ($data['category']) {
                             $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
                         }
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
                         Notification::make()
@@ -86,7 +89,7 @@ class ViewGroup extends ViewRecord
                             'group' => $group->name,
                             'group_id' => $group->id,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
                         Notification::make()
@@ -107,7 +110,7 @@ class ViewGroup extends ViewRecord
                         $record->channels()->update([
                             'enabled' => true,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
                         Notification::make()
@@ -128,7 +131,7 @@ class ViewGroup extends ViewRecord
                         $record->channels()->update([
                             'enabled' => false,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        SyncPlaylistChildrenJob::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
                         Notification::make()

--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -9,7 +9,6 @@ use App\Models\Playlist;
 use App\Rules\CheckIfUrlOrLocalPath;
 use Carbon\Carbon;
 use Filament\Forms;
-use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
@@ -34,7 +33,7 @@ use App\Livewire\XtreamApiInfo;
 use App\Models\Category;
 use App\Models\SourceGroup;
 use App\Services\EpgCacheService;
-use App\Jobs\SyncPlaylistChildren;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
 use Illuminate\Contracts\Support\Htmlable;
@@ -72,10 +71,9 @@ class PlaylistResource extends Resource
         return 0;
     }
 
-    public static function form(Form $form): Form
+    public static function form(Forms\Form $form): Forms\Form
     {
-        return $form
-            ->schema(self::getForm());
+        return $form->schema(self::getForm());
     }
 
     public static function table(Table $table): Table
@@ -432,7 +430,7 @@ class PlaylistResource extends Resource
                         ->color('danger')
                         ->action(function ($record) {
                             $record->series()->delete();
-                            SyncPlaylistChildren::debounce($record, []);
+                            SyncPlaylistChildrenJob::debounce($record, []);
                         })
                         ->requiresConfirmation()
                         ->icon('heroicon-s-trash')

--- a/app/Filament/Resources/VodResource.php
+++ b/app/Filament/Resources/VodResource.php
@@ -14,6 +14,8 @@ use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Jobs\SyncPlaylistChildren as SyncPlaylistChildrenJob;
+use App\Filament\BulkActions\HandlesSourcePlaylist as HandlesSourcePlaylistTrait;
 use App\Rules\CheckIfUrlOrLocalPath;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -31,9 +33,11 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class VodResource extends Resource
 {
+    use HandlesSourcePlaylistTrait;
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -414,55 +418,8 @@ class VodResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Channel::class, 'channels', 'source_id', 'channel(s)', '')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([
@@ -494,6 +451,7 @@ class VodResource extends Resource
                                 'group_id' => $group->id,
                             ]);
                         }
+                        SyncPlaylistChildrenJob::debounce($group->playlist, []);
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/tests/Feature/ChannelAddToCustomPlaylistTest.php
+++ b/tests/Feature/ChannelAddToCustomPlaylistTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Filament\Resources\ChannelResource;
+use App\Models\CustomPlaylist;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function getChannelAddAction(EloquentCollection $records)
+{
+    $bulkActions = ChannelResource::getTableBulkActions();
+    $bulkActionGroup = $bulkActions[0];
+    $addAction = collect($bulkActionGroup->getActions())->first(fn($action) => $action->getName() === 'add');
+    $addAction->records($records);
+    return $addAction;
+}
+
+it('adds channels without source selector when no duplicates exist', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $channel = Channel::factory()->for($user)->create([
+        'playlist_id' => $playlist->id,
+        'source_id' => 1,
+        'title' => 'A',
+    ]);
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $records = new EloquentCollection([$channel]);
+
+    Queue::fake();
+
+    $addAction = getChannelAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+    ]);
+
+    expect($custom->channels()->pluck('id'))->toContain($channel->id);
+});
+
+it('requires source playlist for duplicates and applies overrides', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentA = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childA  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentB = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childB  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = new EloquentCollection([$childA, $childB]);
+
+    Queue::fake();
+    $pairKey = $parent->id . '-' . $child->id;
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $addAction = getChannelAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+        'source_playlists' => [$pairKey => $parent->id],
+        'source_playlists_items' => [
+            $pairKey => [
+                $childB->id => $child->id,
+            ],
+        ],
+    ]);
+
+    expect($custom->channels()->pluck('id')->all())
+        ->toEqualCanonicalizing([$parentA->id, $childB->id]);
+});
+
+it('prompts once per duplicate group', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentA = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childACh = Channel::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_id' => 1, 'title' => 'A']);
+    $parentB = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childBCh = Channel::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = new EloquentCollection([$childACh, $childBCh]);
+
+    Queue::fake();
+    $keys = [$parent->id . '-' . $childA->id, $parent->id . '-' . $childB->id];
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $addAction = getChannelAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+        'source_playlists' => [
+            $keys[0] => $parent->id,
+            $keys[1] => $childB->id,
+        ],
+    ]);
+
+    expect($custom->channels()->pluck('id')->all())
+        ->toEqualCanonicalizing([$parentA->id, $childBCh->id]);
+});
+

--- a/tests/Feature/MoveToGroupSyncsChildrenTest.php
+++ b/tests/Feature/MoveToGroupSyncsChildrenTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Filament\Resources\ChannelResource;
+use App\Filament\Resources\SeriesResource;
+use App\Filament\Resources\VodResource;
+use App\Jobs\SyncPlaylistChildren;
+use App\Models\Category;
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+it('dispatches child sync when moving channels to a group', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $group = Group::factory()->for($user)->create(['playlist_id' => $parent->id]);
+    $channel = Channel::factory()->for($user)->create([
+        'playlist_id' => $parent->id,
+        'group_id' => $group->id,
+    ]);
+
+    $bulkActions = ChannelResource::getTableBulkActions();
+    $bulkActionGroup = $bulkActions[0];
+    $moveAction = collect($bulkActionGroup->getActions())
+        ->first(fn ($action) => $action->getName() === 'move');
+
+    $moveAction->records(new EloquentCollection([$channel]))
+        ->call(['playlist' => $parent->id, 'group' => $group->id]);
+
+    Queue::assertPushed(SyncPlaylistChildren::class, fn ($job) => $job->playlist->is($parent));
+});
+
+it('dispatches child sync when moving series to a category', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $origCategory = Category::factory()->for($user)->for($parent)->create();
+    $targetCategory = Category::factory()->for($user)->for($parent)->create();
+
+    $series = Series::factory()->for($user)->for($parent)->for($origCategory)->create();
+
+    $bulkActions = SeriesResource::getTableBulkActions();
+    $bulkActionGroup = $bulkActions[0];
+    $moveAction = collect($bulkActionGroup->getActions())
+        ->first(fn ($action) => $action->getName() === 'move');
+
+    $moveAction->records(new EloquentCollection([$series]))
+        ->call(['category' => $targetCategory->id]);
+
+    Queue::assertPushed(SyncPlaylistChildren::class, fn ($job) => $job->playlist->is($parent));
+});
+
+it('dispatches child sync when moving vod channels to a group', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $group = Group::factory()->for($user)->create(['playlist_id' => $parent->id]);
+    $vod = Channel::factory()->for($user)->create([
+        'playlist_id' => $parent->id,
+        'group_id' => $group->id,
+        'is_vod' => true,
+    ]);
+
+    $bulkActions = VodResource::getTableBulkActions();
+    $bulkActionGroup = $bulkActions[0];
+    $moveAction = collect($bulkActionGroup->getActions())
+        ->first(fn ($action) => $action->getName() === 'move');
+
+    $moveAction->records(new EloquentCollection([$vod]))
+        ->call(['playlist' => $parent->id, 'group' => $group->id]);
+
+    Queue::assertPushed(SyncPlaylistChildren::class, fn ($job) => $job->playlist->is($parent));
+});
+

--- a/tests/Feature/SeriesAddToCustomPlaylistTest.php
+++ b/tests/Feature/SeriesAddToCustomPlaylistTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Filament\Resources\SeriesResource;
+use App\Models\CustomPlaylist;
+use App\Models\Playlist;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function getSeriesAddAction(EloquentCollection $records)
+{
+    $bulkActions = SeriesResource::getTableBulkActions();
+    $bulkActionGroup = $bulkActions[0];
+    $addAction = collect($bulkActionGroup->getActions())->first(fn($action) => $action->getName() === 'add');
+    $addAction->records($records);
+    return $addAction;
+}
+
+it('adds series without source selector when no duplicates exist', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $series = Series::factory()->for($user)->for($playlist)->create([
+        'source_series_id' => 1,
+        'name' => 'S1',
+    ]);
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $records = new EloquentCollection([$series]);
+
+    Queue::fake();
+
+    $addAction = getSeriesAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+    ]);
+
+    expect($custom->series()->pluck('id'))->toContain($series->id);
+});
+
+it('requires source playlist for duplicates and applies overrides (series)', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentA = Series::factory()->for($user)->for($parent)->create(['source_series_id' => 1, 'name' => 'A']);
+    $childA  = Series::factory()->for($user)->for($child)->create(['source_series_id' => 1, 'name' => 'A']);
+    $parentB = Series::factory()->for($user)->for($parent)->create(['source_series_id' => 2, 'name' => 'B']);
+    $childB  = Series::factory()->for($user)->for($child)->create(['source_series_id' => 2, 'name' => 'B']);
+
+    $records = new EloquentCollection([$childA, $childB]);
+
+    Queue::fake();
+    $pairKey = $parent->id . '-' . $child->id;
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $addAction = getSeriesAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+        'source_playlists' => [$pairKey => $parent->id],
+        'source_playlists_items' => [
+            $pairKey => [
+                $childB->id => $child->id,
+            ],
+        ],
+    ]);
+
+    expect($custom->series()->pluck('id')->all())
+        ->toEqualCanonicalizing([$parentA->id, $childB->id]);
+});
+
+it('prompts once per duplicate series group', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentA = Series::factory()->for($user)->for($parent)->create(['source_series_id' => 1, 'name' => 'A']);
+    $childASe = Series::factory()->for($user)->for($childA)->create(['source_series_id' => 1, 'name' => 'A']);
+    $parentB = Series::factory()->for($user)->for($parent)->create(['source_series_id' => 2, 'name' => 'B']);
+    $childBSe = Series::factory()->for($user)->for($childB)->create(['source_series_id' => 2, 'name' => 'B']);
+
+    $records = new EloquentCollection([$childASe, $childBSe]);
+
+    Queue::fake();
+    $keys = [$parent->id . '-' . $childA->id, $parent->id . '-' . $childB->id];
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $addAction = getSeriesAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+        'source_playlists' => [
+            $keys[0] => $parent->id,
+            $keys[1] => $childB->id,
+        ],
+    ]);
+
+    expect($custom->series()->pluck('id')->all())
+        ->toEqualCanonicalizing([$parentA->id, $childBSe->id]);
+});
+

--- a/tests/Feature/SourcePlaylistOverrideTest.php
+++ b/tests/Feature/SourcePlaylistOverrideTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+function makeHandler() {
+    return new class {
+        use HandlesSourcePlaylist {
+            getSourcePlaylistData as public;
+            mapRecordsToSourcePlaylist as public;
+        }
+    };
+}
+
+it('applies bulk source selection when no overrides', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel1 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel1  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentChannel2 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childChannel2  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = collect([$childChannel1, $childChannel2]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+    $pairKey = $groups->keys()->first();
+
+    $mapped = $handler::mapRecordsToSourcePlaylist(
+        $records,
+        ['source_playlists' => [$pairKey => $parent->id]],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+
+    expect($mapped->pluck('id')->all())->toEqual([$parentChannel1->id, $parentChannel2->id]);
+});
+
+it('applies per-item overrides', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel1 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel1  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentChannel2 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childChannel2  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = collect([$childChannel1, $childChannel2]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+    $pairKey = $groups->keys()->first();
+
+    $mapped = $handler::mapRecordsToSourcePlaylist(
+        $records,
+        [
+            'source_playlists' => [$pairKey => $parent->id],
+            'source_playlists_items' => [
+                $pairKey => [
+                    $childChannel2->id => $child->id,
+                ],
+            ],
+        ],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+
+    expect($mapped->pluck('id')->all())->toEqual([$parentChannel1->id, $childChannel2->id]);
+});
+
+it('maps records to correct groups when channel exists in multiple child playlists', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childAChannel = Channel::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_id' => 1, 'title' => 'A']);
+    $childBChannel = Channel::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_id' => 1, 'title' => 'A']);
+
+    $records = collect([$childAChannel, $childBChannel]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+
+    $mapped = $handler::mapRecordsToSourcePlaylist(
+        $records,
+        [
+            'source_playlists' => [
+                $parent->id . '-' . $childA->id => $parent->id,
+                $parent->id . '-' . $childB->id => $childB->id,
+            ],
+        ],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+
+    expect($mapped->pluck('id')->all())->toEqual([$parentChannel->id, $childBChannel->id]);
+});
+
+it('fails validation when selections are missing', function () {
+    $handler = makeHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentChannel1 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A']);
+    $childChannel1  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A']);
+    $parentChannel2 = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B']);
+    $childChannel2  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B']);
+
+    $records = collect([$childChannel1, $childChannel2]);
+
+    $data = $handler::getSourcePlaylistData($records, 'channels', 'source_id');
+    [$groups] = $data;
+    $pairKey = $groups->keys()->first();
+
+    $handler::mapRecordsToSourcePlaylist(
+        $records,
+        [
+            'source_playlists_items' => [
+                $pairKey => [
+                    $childChannel1->id => $parent->id,
+                ],
+            ],
+        ],
+        'channels',
+        'source_id',
+        Channel::class,
+        $data
+    );
+})->throws(ValidationException::class);

--- a/tests/Feature/SourcePlaylistSelectorVisibilityTest.php
+++ b/tests/Feature/SourcePlaylistSelectorVisibilityTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\Channel;
+use App\Models\Series;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Filament\Forms;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+dataset('mediaTypes', [
+    'channels' => [Channel::class, 'channels', 'source_id', 'channel', []],
+    'series'   => [Series::class, 'series', 'source_series_id', 'series', []],
+    'vod'      => [Channel::class, 'channels', 'source_id', 'channel', ['is_vod' => true]],
+]);
+
+function makeFormHandler() {
+    return new class {
+        use HandlesSourcePlaylist {
+            buildSourcePlaylistForm as public;
+        }
+    };
+}
+
+it('hides the source playlist selector when no duplicates exist', function (string $modelClass, string $relation, string $sourceKey, string $label, array $extra) {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $record = $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $playlist->id,
+        $sourceKey    => 1,
+    ]));
+
+    $form = $handler::buildSourcePlaylistForm(collect([$record]), $relation, $sourceKey, $label);
+
+    expect($form)->toBeEmpty();
+})->with('mediaTypes');
+
+it('renders one required selector for a single parent-child duplicate pair', function (string $modelClass, string $relation, string $sourceKey, string $label, array $extra) {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $parent->id,
+        $sourceKey    => 1,
+    ]));
+
+    $childRecord = $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $child->id,
+        $sourceKey    => 1,
+    ]));
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childRecord]), $relation, $sourceKey, $label);
+
+    expect($form)->toHaveCount(1);
+
+    $select = $form[0]->getChildComponents()[0];
+
+    expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+    expect($select->isRequired())->toBeTrue();
+})->with('mediaTypes');
+
+it('renders selector when selecting the parent item of a duplicate pair', function (string $modelClass, string $relation, string $sourceKey, string $label, array $extra) {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentRecord = $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $parent->id,
+        $sourceKey    => 1,
+    ]));
+    $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $child->id,
+        $sourceKey    => 1,
+    ]));
+
+    $form = $handler::buildSourcePlaylistForm(collect([$parentRecord]), $relation, $sourceKey, $label);
+
+    expect($form)->toHaveCount(1);
+    $select = $form[0]->getChildComponents()[0];
+    expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+    expect($select->isRequired())->toBeTrue();
+})->with('mediaTypes');
+
+it('renders one selector per duplicated parent-child group', function (string $modelClass, string $relation, string $sourceKey, string $label, array $extra) {
+    $handler = makeFormHandler();
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $parent->id,
+        $sourceKey    => 1,
+    ]));
+
+    $childRecordA = $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $childA->id,
+        $sourceKey    => 1,
+    ]));
+    $childRecordB = $modelClass::factory()->for($user)->create(array_merge($extra, [
+        'playlist_id' => $childB->id,
+        $sourceKey    => 1,
+    ]));
+
+    $form = $handler::buildSourcePlaylistForm(collect([$childRecordA, $childRecordB]), $relation, $sourceKey, $label);
+
+    expect($form)->toHaveCount(2);
+
+    foreach ($form as $fieldset) {
+        $select = $fieldset->getChildComponents()[0];
+        expect($select)->toBeInstanceOf(Forms\Components\Select::class);
+        expect($select->isRequired())->toBeTrue();
+    }
+})->with('mediaTypes');
+

--- a/tests/Feature/VodAddToCustomPlaylistTest.php
+++ b/tests/Feature/VodAddToCustomPlaylistTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Filament\Resources\VodResource;
+use App\Models\CustomPlaylist;
+use App\Models\Playlist;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function getVodAddAction(EloquentCollection $records)
+{
+    $bulkActions = VodResource::getTableBulkActions();
+    $bulkActionGroup = $bulkActions[0];
+    $addAction = collect($bulkActionGroup->getActions())->first(fn($action) => $action->getName() === 'add');
+    $addAction->records($records);
+    return $addAction;
+}
+
+it('adds vod channels without source selector when no duplicates exist', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $playlist = Playlist::factory()->for($user)->create();
+    $vod = Channel::factory()->for($user)->create([
+        'playlist_id' => $playlist->id,
+        'source_id' => 1,
+        'title' => 'V1',
+        'is_vod' => true,
+    ]);
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $records = new EloquentCollection([$vod]);
+
+    Queue::fake();
+
+    $addAction = getVodAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+    ]);
+
+    expect($custom->channels()->pluck('id'))->toContain($vod->id);
+});
+
+it('requires source playlist for duplicate vod channels and applies overrides', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentA = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $childA  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $parentB = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B', 'is_vod' => true]);
+    $childB  = Channel::factory()->for($user)->create(['playlist_id' => $child->id, 'source_id' => 2, 'title' => 'B', 'is_vod' => true]);
+
+    $records = new EloquentCollection([$childA, $childB]);
+
+    Queue::fake();
+    $pairKey = $parent->id . '-' . $child->id;
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $addAction = getVodAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+        'source_playlists' => [$pairKey => $parent->id],
+        'source_playlists_items' => [
+            $pairKey => [
+                $childB->id => $child->id,
+            ],
+        ],
+    ]);
+
+    expect($custom->channels()->pluck('id')->all())
+        ->toEqualCanonicalizing([$parentA->id, $childB->id]);
+});
+
+it('prompts once per duplicate vod group', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $parentA = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $childAV = Channel::factory()->for($user)->create(['playlist_id' => $childA->id, 'source_id' => 1, 'title' => 'A', 'is_vod' => true]);
+    $parentB = Channel::factory()->for($user)->create(['playlist_id' => $parent->id, 'source_id' => 2, 'title' => 'B', 'is_vod' => true]);
+    $childBV = Channel::factory()->for($user)->create(['playlist_id' => $childB->id, 'source_id' => 2, 'title' => 'B', 'is_vod' => true]);
+
+    $records = new EloquentCollection([$childAV, $childBV]);
+
+    Queue::fake();
+    $keys = [$parent->id . '-' . $childA->id, $parent->id . '-' . $childB->id];
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+
+    $addAction = getVodAddAction($records);
+    $addAction->call([
+        'playlist' => $custom->id,
+        'category' => null,
+        'source_playlists' => [
+            $keys[0] => $parent->id,
+            $keys[1] => $childB->id,
+        ],
+    ]);
+
+    expect($custom->channels()->pluck('id')->all())
+        ->toEqualCanonicalizing([$parentA->id, $childBV->id]);
+});
+


### PR DESCRIPTION
## Summary
- include parents and their children when scanning for duplicate playlist entries so parent-only selections still trigger the source selector
- cover selecting a parent record in the source-playlist visibility test suite
- alias SyncPlaylistChildren job imports in Filament resources to avoid class name collisions
- import HandlesSourcePlaylist trait in CategoryResource and ViewCategory to resolve missing-trait fatal errors
- alias HandlesSourcePlaylist trait imports across Filament resources to prevent naming conflicts
- import HandlesSourcePlaylist trait into GroupResource to resolve missing trait error
- import HandlesSourcePlaylist trait in ViewGroup page so bulk actions can reuse shared helpers without runtime errors
- fix PlaylistResource form type hint to use Filament\Forms\Form

## Testing
- `composer install --no-interaction --no-ansi --no-progress`
- `BROADCAST_DRIVER=log ./vendor/bin/pest tests/Feature/SourcePlaylistSelectorVisibilityTest.php` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68bcea88474c8321b04398f7e2aeaf50