### PR TITLE
Prompt for source playlist when adding to custom playlists

### DIFF
--- a/app/Console/Commands/RunScheduledBackups.php
+++ b/app/Console/Commands/RunScheduledBackups.php
@@ -8,7 +8,7 @@ use Cron\CronExpression;
 use Illuminate\Console\Command;
 use ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackup;
 use Spatie\Backup\BackupDestination\Backup;
-use Spatie\Backup\BackupDestination\BackupDestination as SpatieBackupDestination;
+use Spatie\Backup\BackupDestination\BackupDestination;
 
 class RunScheduledBackups extends Command
 {
@@ -51,7 +51,7 @@ class RunScheduledBackups extends Command
                         $toDelete = $data->slice($max - 1);
                         foreach ($toDelete as $record) {
                             $this->info("Deleting old backup: {$record['path']}");
-                            SpatieBackupDestination::create($record['disk'], config('backup.backup.name'))
+                            BackupDestination::create($record['disk'], config('backup.backup.name'))
                                 ->backups()
                                 ->first(function (Backup $backup) use ($record) {
                                     return $backup->path() === $record['path'];

--- a/app/Console/Commands/TestBroadcasting.php
+++ b/app/Console/Commands/TestBroadcasting.php
@@ -3,7 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\User;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Console\Command;
 
 class TestBroadcasting extends Command
@@ -40,7 +40,7 @@ class TestBroadcasting extends Command
         }
 
         $this->info('Testing broadcasting...');
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title("Broadcast testing")
             ->body('Testing system broadcasting')

--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -1,0 +1,401 @@
+<?php
+
+namespace App\Filament\BulkActions;
+
+use App\Models\CustomPlaylist;
+use App\Models\Playlist;
+use Filament\Forms;
+use Filament\Forms\Components\Actions;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Tables;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Provides helpers for bulk actions that need to resolve the correct
+ * source playlist when a record exists in both a parent playlist and one
+ * or more of its children.
+ *
+ * Example usage:
+ *
+ * ```php
+ * class ChannelResource extends Resource
+ * {
+ *     use \App\Filament\BulkActions\HandlesSourcePlaylist;
+ *
+ *     public static function getTableBulkActions(): array
+ *     {
+ *         return [
+ *             self::addToCustomPlaylistBulkAction(
+ *                 \App\Models\Channel::class,
+ *                 'channels',
+ *                 'source_id',
+ *                 'channel',
+ *                 'channel'
+ *             ),
+ *         ];
+ *     }
+ * }
+ * ```
+ */
+trait HandlesSourcePlaylist
+{
+    /**
+     * Build duplicate playlist metadata for the given records.
+     *
+     * @param Collection $records   Selected records from the bulk action.
+     * @param string     $relation  Relationship name used to query playlist items (channels, series, etc.).
+     * @param string     $sourceKey Source identifier column on the related model.
+     * @return array{0: Collection, 1: bool, 2: Collection, 3: Collection} Tuple containing
+     *                                             duplicate groups, whether a source playlist is
+     *                                             needed, the source IDs of the records, and a
+     *                                             map of composite playlist/source keys to their
+     *                                             parent-child group key.
+    */
+    protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
+    {
+        $recordPlaylistIds = $records->pluck('playlist_id')->unique();
+        $recordSourceIds   = $records->pluck($sourceKey)->unique();
+
+        $parentIds = Playlist::whereIn('id', $recordPlaylistIds)
+            ->pluck('parent_id')
+            ->filter()
+            ->unique()
+            ->all();
+
+        $playlists = Playlist::where('user_id', auth()->id())
+            ->select('id', 'parent_id', 'name')
+            ->where(function ($query) use ($recordPlaylistIds, $parentIds) {
+                $query->whereIn('id', $recordPlaylistIds)
+                    ->orWhereIn('parent_id', $recordPlaylistIds);
+
+                if (! empty($parentIds)) {
+                    $query->orWhereIn('id', $parentIds)
+                        ->orWhereIn('parent_id', $parentIds);
+                }
+            })
+            ->whereHas($relation, fn ($q) => $q->whereIn($sourceKey, $recordSourceIds))
+            ->with([
+                $relation => fn ($q) => $q
+                    ->select('id', 'playlist_id', $sourceKey)
+                    ->whereIn($sourceKey, $recordSourceIds),
+            ])
+            ->get();
+
+        $playlistMap = $playlists->keyBy('id');
+
+        $groups = [];
+
+        $playlists
+            ->flatMap(fn ($playlist) => ($playlist->$relation ?? collect())->map(fn ($item) => [
+                'source_id'   => $item->$sourceKey,
+                'playlist_id' => $playlist->id,
+            ]))
+            ->groupBy('source_id')
+            ->each(function ($group, $sourceId) use (&$groups, $playlistMap) {
+                $ids = $group->pluck('playlist_id')->unique();
+
+                if ($ids->count() <= 1) {
+                    return;
+                }
+
+                foreach ($ids as $id) {
+                    $playlist = $playlistMap[$id];
+
+                    if ($playlist->parent_id && $ids->contains($playlist->parent_id)) {
+                        $pairKey = $playlist->parent_id . '-' . $id;
+
+                        $groups[$pairKey] ??= [
+                            'parent_id'     => $playlist->parent_id,
+                            'child_id'      => $id,
+                            'playlists'     => $playlistMap
+                                ->only([$playlist->parent_id, $id])
+                                ->map->name,
+                            'source_ids'    => [],
+                            'composite_keys'=> [],
+                        ];
+
+                        $groups[$pairKey]['source_ids'][]     = $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $id . ':' . $sourceId;
+                        $groups[$pairKey]['composite_keys'][] = $playlist->parent_id . ':' . $sourceId;
+                    }
+                }
+            });
+
+        $duplicateGroups = collect($groups);
+
+        // Map composite playlist & source IDs to their parent-child pair
+        $sourceToGroup = $duplicateGroups
+            ->flatMap(fn ($group, $pairKey) => collect($group['composite_keys'])
+                ->unique()
+                ->mapWithKeys(fn ($key) => [$key => $pairKey]));
+
+        // Store the selected record details under their respective group
+        foreach ($records as $record) {
+            $sourceId  = $record->$sourceKey;
+            $composite = $record->playlist_id . ':' . $sourceId;
+
+            if (! $sourceToGroup->has($composite)) {
+                continue;
+            }
+
+            $pairKey = $sourceToGroup[$composite];
+
+            $group = $duplicateGroups[$pairKey];
+            $group['records'][$record->id] = [
+                'id'          => $record->id,
+                'title'       => $record->title ?? $record->name ?? '',
+                'source_id'   => $sourceId,
+                'playlist_id' => $record->playlist_id,
+            ];
+            $duplicateGroups[$pairKey] = $group;
+        }
+
+        $needsSourcePlaylist = $duplicateGroups->isNotEmpty();
+
+        return [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup];
+    }
+
+    /**
+     * Build form fields allowing users to choose the source playlist for
+     * duplicate parent/child groups and optionally override individual
+     * records within those groups.
+     *
+     * @param Collection      $records            Records selected in the bulk action.
+     * @param string          $relation           Relationship name used to fetch playlist items.
+     * @param string          $sourceKey          Column containing the source ID on the related model.
+     * @param string          $itemLabel          Human-readable label for the record type (channel, series, etc.).
+     * @param array|null      $sourcePlaylistData Cached metadata returned from {@see getSourcePlaylistData}.
+     *                                           Passed by reference so callers can reuse the computed data.
+     * @return array                             Array of Filament form components for inclusion in the bulk action.
+     */
+    protected static function buildSourcePlaylistForm(
+        Collection $records,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        ?array &$sourcePlaylistData = null
+    ): array {
+        if ($sourcePlaylistData === null) {
+            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+        }
+
+        [$duplicateGroups, $needsSourcePlaylist] = $sourcePlaylistData;
+
+        if (! $needsSourcePlaylist) {
+            return [];
+        }
+
+        $fields = [];
+
+        foreach ($duplicateGroups as $pairKey => $group) {
+            $parentName = $group['playlists'][$group['parent_id']];
+            $childName  = $group['playlists'][$group['child_id']];
+
+            $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
+                ->schema([
+                    Forms\Components\Select::make("source_playlists.{$pairKey}")
+                        ->label('Use items from:')
+                        ->options($group['playlists']->toArray())
+                        ->required()
+                        ->searchable(),
+                    Actions::make([
+                        Action::make("view_affected_{$pairKey}")
+                            ->label('View affected items')
+                            ->modalHeading("Items in {$parentName} ↔ {$childName}")
+                            ->statePath("source_playlists_items.{$pairKey}")
+                            ->form(
+                                collect($group['records'] ?? [])->map(fn ($record) =>
+                                    Forms\Components\Select::make((string) $record['id'])
+                                        ->label($record['title'])
+                                        ->options($group['playlists']->toArray())
+                                        ->placeholder('Use group selection')
+                                        ->searchable()
+                                )->toArray()
+                            ),
+                    ]),
+                ]);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Resolve each selected record to the appropriate source playlist entry
+     * based on the user's selections.
+     *
+     * Performs validation to ensure every duplicate parent/child group has a
+     * source playlist chosen, and replaces records with their counterpart from
+     * the selected source playlist.
+     *
+     * @param Collection $records           Records originally selected in the bulk action.
+     * @param array      $data              Form data submitted by the user.
+     * @param string     $relation          Relationship name used to fetch playlist items.
+     * @param string     $sourceKey         Source identifier column on the related model.
+     * @param string     $modelClass        Fully qualified model class name for the records.
+     * @param array|null $sourcePlaylistData Cached metadata from {@see getSourcePlaylistData}.
+     *                                       Passed by reference to avoid recomputation.
+     * @return Collection                    Collection of records mapped to their chosen source playlist.
+     * @throws ValidationException           If any duplicate group lacks a source selection.
+     */
+    protected static function mapRecordsToSourcePlaylist(
+        Collection $records,
+        array $data,
+        string $relation,
+        string $sourceKey,
+        string $modelClass,
+        ?array $sourcePlaylistData = null
+    ): Collection {
+        if ($sourcePlaylistData === null) {
+            $sourcePlaylistData = self::getSourcePlaylistData($records, $relation, $sourceKey);
+        }
+
+        [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
+
+        if ($needsSourcePlaylist) {
+            $selected     = collect($data['source_playlists'] ?? []);
+            $itemSelected = collect($data['source_playlists_items'] ?? []);
+
+            foreach ($duplicateGroups as $pairKey => $group) {
+                $bulk   = $selected[$pairKey] ?? null;
+                $items  = collect($itemSelected[$pairKey] ?? [])->filter();
+                $count  = count($group['records'] ?? []);
+
+                if (! $bulk && $items->count() !== $count) {
+                    throw ValidationException::withMessages([
+                        'source_playlists' => 'Please select a source playlist for each duplicated group.',
+                    ]);
+                }
+            }
+
+            $playlistIds = $selected->filter()->values();
+            $playlistIds = $playlistIds->merge(
+                $itemSelected->flatMap(fn ($items) => collect($items)->filter()->values())
+            )->unique();
+
+            $sourceMaps = $modelClass::query()
+                ->whereIn('playlist_id', $playlistIds)
+                ->whereIn($sourceKey, $recordSourceIds)
+                ->select('id', 'playlist_id', $sourceKey)
+                ->get()
+                ->groupBy('playlist_id')
+                ->map->keyBy($sourceKey);
+
+            $records = $records->map(function ($record) use ($selected, $itemSelected, $sourceMaps, $sourceToGroup, $sourceKey) {
+                $sourceId  = $record->$sourceKey;
+                $composite = $record->playlist_id . ':' . $sourceId;
+
+                if ($sourceToGroup->has($composite)) {
+                    $pairKey    = $sourceToGroup[$composite];
+                    $override   = $itemSelected[$pairKey][$record->id] ?? null;
+                    $playlistId = $override ?: ($selected[$pairKey] ?? null);
+
+                    return $playlistId && isset($sourceMaps[$playlistId][$sourceId])
+                        ? $sourceMaps[$playlistId][$sourceId]
+                        : $record;
+                }
+
+                return $record;
+            });
+        }
+
+        return $records;
+    }
+
+    /**
+     * Construct a Filament bulk action that adds the selected records to a
+     * custom playlist, including optional source playlist disambiguation.
+     *
+     * @param string $modelClass    Fully qualified model class for the records.
+     * @param string $relation      Relationship name used by the custom playlist (channels, series, vods).
+     * @param string $sourceKey     Column containing the source ID on the related model.
+     * @param string $itemLabel     Human-readable label for the record type.
+     * @param string $tagType       Tag type used when assigning categories/groups.
+     * @param string $categoryLabel Label displayed for the category select.
+     * @return Tables\Actions\BulkAction Configured bulk action ready to attach to a Filament table.
+     */
+    protected static function buildAddToCustomPlaylistAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group'
+    ): Tables\Actions\BulkAction {
+        $sourcePlaylistData = null;
+
+        return Tables\Actions\BulkAction::make('add')
+            ->label('Add to Custom Playlist')
+            ->form(function (Collection $records) use ($relation, $sourceKey, $itemLabel, $tagType, $categoryLabel, &$sourcePlaylistData): array {
+                $form = [
+                    Forms\Components\Select::make('playlist')
+                        ->required()
+                        ->live()
+                        ->label('Custom Playlist')
+                        ->helperText("Select the custom playlist you would like to add the selected {$itemLabel} to.")
+                        ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
+                        ->afterStateUpdated(fn (Set $set, $state) => $state ? $set('category', null) : null)
+                        ->searchable(),
+                    Forms\Components\Select::make('category')
+                        ->label($categoryLabel)
+                        ->disabled(fn (Get $get) => ! $get('playlist'))
+                        ->helperText(fn (Get $get) => ! $get('playlist')
+                            ? 'Select a custom playlist first.'
+                            : 'Select the ' . ($categoryLabel === 'Custom Group' ? 'group' : 'category') .
+                                ' you would like to assign to the selected ' . $itemLabel . ' to.')
+                        ->options(function ($get) use ($tagType) {
+                            $customList = CustomPlaylist::find($get('playlist'));
+                            return $customList ? $customList->tags()
+                                ->where('type', $customList->uuid . $tagType)
+                                ->get()
+                                ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
+                                ->toArray() : [];
+                        })
+                        ->searchable(),
+                ];
+
+                $form = array_merge(
+                    $form,
+                    self::buildSourcePlaylistForm($records, $relation, $sourceKey, $itemLabel, $sourcePlaylistData)
+                );
+
+                return $form;
+            })
+            ->action(function (Collection $records, array $data) use ($modelClass, $relation, $sourceKey, &$sourcePlaylistData): void {
+                $records = self::mapRecordsToSourcePlaylist($records, $data, $relation, $sourceKey, $modelClass, $sourcePlaylistData);
+
+                $playlist = CustomPlaylist::findOrFail($data['playlist']);
+                $playlist->$relation()->syncWithoutDetaching($records->pluck('id'));
+                if ($data['category']) {
+                    $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
+                }
+            })
+            ->after(function () use ($itemLabel) {
+                FilamentNotification::make()
+                    ->success()
+                    ->title(ucfirst($itemLabel) . ' added to custom playlist')
+                    ->body("The selected {$itemLabel} have been added to the chosen custom playlist.")
+                    ->send();
+            })
+            ->deselectRecordsAfterCompletion()
+            ->requiresConfirmation()
+            ->icon('heroicon-o-play')
+            ->modalIcon('heroicon-o-play')
+            ->modalDescription("Add the selected {$itemLabel} to the chosen custom playlist.")
+            ->modalSubmitActionLabel('Add now');
+    }
+
+    public static function addToCustomPlaylistBulkAction(
+        string $modelClass,
+        string $relation,
+        string $sourceKey,
+        string $itemLabel,
+        string $tagType,
+        string $categoryLabel = 'Custom Group'
+    ): Tables\Actions\BulkAction {
+        return self::buildAddToCustomPlaylistAction($modelClass, $relation, $sourceKey, $itemLabel, $tagType, $categoryLabel);
+    }
+}

--- a/app/Filament/Concerns/DisplaysPlaylistMembership.php
+++ b/app/Filament/Concerns/DisplaysPlaylistMembership.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Filament\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+trait DisplaysPlaylistMembership
+{
+    protected static function getPlaylistNames(Model $record, string $sourceKey): Collection
+    {
+        if (empty($record->{$sourceKey})) {
+            return collect([$record->playlist?->name])->filter();
+        }
+
+        return $record->newQuery()
+            ->where('user_id', $record->user_id)
+            ->where($sourceKey, $record->{$sourceKey})
+            ->with('playlist')
+            ->get()
+            ->pluck('playlist.name')
+            ->filter();
+    }
+
+    protected static function playlistDisplay(Model $record, string $sourceKey): string
+    {
+        $names = self::getPlaylistNames($record, $sourceKey);
+        $first = $names->first() ?? '';
+        $count = $names->count() - 1;
+        return $count > 0 ? sprintf('%s +%d', $first, $count) : $first;
+    }
+
+    protected static function playlistTooltip(Model $record, string $sourceKey): ?string
+    {
+        $names = self::getPlaylistNames($record, $sourceKey);
+        return $names->count() > 1 ? $names->implode(', ') : null;
+    }
+}

--- a/app/Filament/Pages/Backups.php
+++ b/app/Filament/Pages/Backups.php
@@ -7,7 +7,7 @@ use App\Jobs\RestoreBackup;
 use App\Models\Epg;
 use App\Models\Playlist;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\File;
@@ -57,7 +57,7 @@ class Backups extends BaseBackups
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new RestoreBackup($data['backup']));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Backup is being restored')
                             ->body('Backup is being restored in the background. Depending on the size of the backup, this could take a while.')
@@ -88,7 +88,7 @@ class Backups extends BaseBackups
                             ]),
                     ])
                     ->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Backup has been uploaded')
                             ->body('Backup file has been uploaded, you can now restore it if needed.')
@@ -110,7 +110,7 @@ class Backups extends BaseBackups
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new CreateBackup($data['include_files'] ?? false));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Backup is being created')
                             ->body('Backup is being created in the background. Depending on the size of your database and files, this could take a while.')

--- a/app/Filament/Pages/CustomDashboard.php
+++ b/app/Filament/Pages/CustomDashboard.php
@@ -4,7 +4,7 @@ namespace App\Filament\Pages;
 
 use Filament\Pages\Dashboard;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 
 class CustomDashboard extends Dashboard
 {

--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Jobs\RestartQueue;
-use App\Rules\CheckIfUrlOrLocalPath;
+use App\Rules\CheckIfUrlOrLocalPath as CheckIfUrlOrLocalPathRule;
 use App\Rules\Cron;
 use App\Settings\GeneralSettings;
 use App\Services\FfmpegCodecService;
@@ -13,7 +13,7 @@ use Filament\Actions;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Pages\SettingsPage;
 use Filament\Support\Enums\MaxWidth;
 use Illuminate\Support\Facades\Artisan;
@@ -41,7 +41,7 @@ class Preferences extends SettingsPage
                         ->dispatch(new RestartQueue());
                 })
                 ->after(function () {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Queue reset')
                         ->body('The queue workers have been restarted and any pending jobs flushed. You may need to manually sync any Playlists or EPGs that were in progress.')
@@ -58,7 +58,7 @@ class Preferences extends SettingsPage
                 ->label('Clear Logo Cache')
                 ->action(fn() => Artisan::call('app:logo-cleanup --force --all'))
                 ->after(function () {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Logo cache cleared')
                         ->body('The logo cache has been cleared successfully.')
@@ -412,7 +412,7 @@ class Preferences extends SettingsPage
                                         Forms\Components\TextInput::make('stream_file_sync_location')
                                             ->label('Series Sync Location')
                                             ->live()
-                                            ->rules([new CheckIfUrlOrLocalPath(localOnly: true, isDirectory: true)])
+                                            ->rules([new CheckIfUrlOrLocalPathRule(localOnly: true, isDirectory: true)])
                                             ->helperText(
                                                 fn($get) => !$get('stream_file_sync_include_series')
                                                     ? 'File location: ' . $get('stream_file_sync_location') . ($get('stream_file_sync_include_season') ?? false ? '/Season 01' : '') . '/S01E01 - Episode Title.strm'
@@ -440,7 +440,7 @@ class Preferences extends SettingsPage
                                         Forms\Components\TextInput::make('vod_stream_file_sync_location')
                                             ->label('VOD Sync Location')
                                             ->live()
-                                            ->rules([new CheckIfUrlOrLocalPath(localOnly: true, isDirectory: true)])
+                                            ->rules([new CheckIfUrlOrLocalPathRule(localOnly: true, isDirectory: true)])
                                             ->helperText(
                                                 fn($get) => 'File location: ' . $get('vod_stream_file_sync_location') . ($get('vod_stream_file_sync_include_season') ?? false ? '/Group Name' : '') . '/VOD Title.strm'
                                             )
@@ -518,7 +518,7 @@ class Preferences extends SettingsPage
 
                                                     // Make sure all required fields are present
                                                     if (empty($formState['smtp_host']) || empty($formState['smtp_port']) || empty($formState['smtp_username']) || empty($formState['smtp_password'])) {
-                                                        Notification::make()
+                                                        FilamentNotification::make()
                                                             ->danger()
                                                             ->title('Missing SMTP Fields')
                                                             ->body('Please fill in all required SMTP fields before sending a test email.')
@@ -541,13 +541,13 @@ class Preferences extends SettingsPage
                                                             ->subject('Test Email from m3u editor');
                                                     });
 
-                                                    Notification::make()
+                                                    FilamentNotification::make()
                                                         ->success()
                                                         ->title('Test Email Sent')
                                                         ->body('Test email sent successfully to ' . $data['to_email'])
                                                         ->send();
                                                 } catch (\Exception $e) {
-                                                    Notification::make()
+                                                    FilamentNotification::make()
                                                         ->danger()
                                                         ->title('Error Sending Test Email')
                                                         ->body($e->getMessage())
@@ -636,7 +636,7 @@ class Preferences extends SettingsPage
                                                     ->helperText('This message will be sent to the WebSocket server, and displayed as a pop-up notification. If you do not see a notification shortly after sending, there is likely an issue with your WebSocket configuration.'),
                                             ])
                                             ->action(function (array $data): void {
-                                                Notification::make()
+                                                FilamentNotification::make()
                                                     ->success()
                                                     ->title("WebSocket Connection Test")
                                                     ->body($data['message'])

--- a/app/Filament/Pages/SharedStreamMonitor.php
+++ b/app/Filament/Pages/SharedStreamMonitor.php
@@ -10,7 +10,7 @@ use App\Services\SharedStreamService;
 use App\Services\StreamMonitorService;
 use Carbon\Carbon;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Pages\Page;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\IconPosition;
@@ -97,7 +97,7 @@ class SharedStreamMonitor extends Page
         $this->sharedStreamService->cleanupInactiveStreams();
         $this->refreshData();
 
-        Notification::make()
+        FilamentNotification::make()
             ->title('Cleanup completed successfully.')
             ->success()
             ->send();
@@ -108,12 +108,12 @@ class SharedStreamMonitor extends Page
         $success = $this->sharedStreamService->stopStream($streamId);
 
         if ($success) {
-            Notification::make()
+            FilamentNotification::make()
                 ->title("Stream {$streamId} stopped successfully.")
                 ->success()
                 ->send();
         } else {
-            Notification::make()
+            FilamentNotification::make()
                 ->title("Failed to stop stream {$streamId}.")
                 ->danger()
                 ->send();
@@ -247,7 +247,7 @@ class SharedStreamMonitor extends Page
 
         $this->refreshInterval = $data['refresh_interval'];
 
-        Notification::make()
+        FilamentNotification::make()
             ->title('Settings saved successfully.')
             ->success()
             ->send();

--- a/app/Filament/Resources/CategoryResource/Pages/ViewCategory.php
+++ b/app/Filament/Resources/CategoryResource/Pages/ViewCategory.php
@@ -5,15 +5,16 @@ namespace App\Filament\Resources\CategoryResource\Pages;
 use App\Filament\Resources\CategoryResource;
 use App\Models\CustomPlaylist;
 use App\Models\Category;
-use App\Jobs\SyncPlaylistChildren;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewCategory extends ViewRecord
 {
+    use \App\Filament\BulkActions\HandlesSourcePlaylist;
+
     protected static string $resource = CategoryResource::class;
 
     protected function getHeaderActions(): array
@@ -52,9 +53,9 @@ class ViewCategory extends ViewRecord
                     ->action(function ($record, array $data): void {
                         $playlist = CustomPlaylist::findOrFail($data['playlist']);
                         $playlist->series()->syncWithoutDetaching($record->series()->pluck('id'));
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series added to custom playlist')
                             ->body('The selected series have been added to the chosen custom playlist.')
@@ -81,9 +82,9 @@ class ViewCategory extends ViewRecord
                         $record->series()->update([
                             'category_id' => $category->id,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series moved to category')
                             ->body('The series have been moved to the chosen category.')
@@ -105,7 +106,7 @@ class ViewCategory extends ViewRecord
                                 ));
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series are being processed')
                             ->body('You will be notified once complete.')
@@ -127,7 +128,7 @@ class ViewCategory extends ViewRecord
                                 ));
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('.strm files are being synced for current category series. Only enabled series will be synced.')
                             ->body('You will be notified once complete.')
@@ -143,10 +144,10 @@ class ViewCategory extends ViewRecord
                     ->label('Enable category series')
                     ->action(function ($record): void {
                         $record->series()->update(['enabled' => true]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Current category series enabled')
                             ->body('The current category series have been enabled.')
@@ -162,10 +163,10 @@ class ViewCategory extends ViewRecord
                     ->label('Disable category series')
                     ->action(function ($record): void {
                         $record->series()->update(['enabled' => false]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Current category series disabled')
                             ->body('The current category series have been disabled.')

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -14,12 +14,12 @@ use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Filament\Concerns\DisplaysPlaylistMembership;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Illuminate\Support\HtmlString;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
 use Filament\Tables;
@@ -30,9 +30,12 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
-class ChannelResource extends Resource
+class ChannelResource extends FilamentResource
 {
+    use \App\Filament\BulkActions\HandlesSourcePlaylist;
+    use DisplaysPlaylistMembership;
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -249,8 +252,10 @@ class ChannelResource extends Resource
                 ->toggleable(isToggledHiddenByDefault: true)
                 ->sortable(),
             Tables\Columns\TextColumn::make('playlist.name')
+                ->label('Playlist')
                 ->hidden(fn() => !$showPlaylist)
-                ->numeric()
+                ->formatStateUsing(fn($state, Channel $record) => self::playlistDisplay($record, 'source_id'))
+                ->tooltip(fn(Channel $record) => self::playlistTooltip($record, 'source_id'))
                 ->toggleable()
                 ->sortable(),
 
@@ -359,55 +364,8 @@ class ChannelResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Channel::class, 'channels', 'source_id', 'channel(s)', '')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([
@@ -440,7 +398,7 @@ class ChannelResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channels moved to group')
                             ->body('The selected channels have been moved to the chosen group.')
@@ -464,7 +422,7 @@ class ChannelResource extends Resource
                                 settings: $data['settings'] ?? [],
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('EPG to Channel mapping')
                             ->body('Mapping started, you will be notified when the process is complete.')
@@ -495,7 +453,7 @@ class ChannelResource extends Resource
                                 'logo_type' => $data['logo_type'],
                             ]);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Preferred icon updated')
                             ->body('The preferred icon has been updated.')
@@ -590,7 +548,7 @@ class ChannelResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channels as failover')
                             ->body('The selected channels have been added as failovers.')
@@ -647,7 +605,7 @@ class ChannelResource extends Resource
                                 channels: $records
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace started')
                             ->body('Find & Replace working in the background. You will be notified once the process is complete.')
@@ -681,7 +639,7 @@ class ChannelResource extends Resource
                                 channels: $records
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace reset started')
                             ->body('Find & Replace reset working in the background. You will be notified once the process is complete.')
@@ -702,7 +660,7 @@ class ChannelResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Selected channels enabled')
                             ->body('The selected channels have been enabled.')
@@ -724,7 +682,7 @@ class ChannelResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Selected channels disabled')
                             ->body('The selected channels have been disabled.')

--- a/app/Filament/Resources/ChannelResource/Pages/ListChannels.php
+++ b/app/Filament/Resources/ChannelResource/Pages/ListChannels.php
@@ -12,7 +12,7 @@ use App\Models\Playlist;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
@@ -93,7 +93,7 @@ class ListChannels extends ListRecords
                                 checkResolution: $data['by_resolution'] ?? false, // Sort failovers by resolution, or by playlist (default behavior)
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channel merge started')
                             ->body('Merging channels in the background. You will be notified once the process is complete.')
@@ -121,7 +121,7 @@ class ListChannels extends ListRecords
                                 playlistId: $data['playlist_id'] ?? null
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channel unmerge started')
                             ->body('Unmerging channels in the background. You will be notified once the process is complete.')
@@ -146,7 +146,7 @@ class ListChannels extends ListRecords
                                 settings: $data['settings'] ?? [],
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('EPG to Channel mapping')
                             ->body('Channel mapping started, you will be notified when the process is complete.')
@@ -217,7 +217,7 @@ class ListChannels extends ListRecords
                                 replace_with: $data['replace_with'] ?? ''
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace started')
                             ->body('Find & Replace working in the background. You will be notified once the process is complete.')
@@ -265,7 +265,7 @@ class ListChannels extends ListRecords
                                 column: $data['column'] ?? 'title',
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace reset started')
                             ->body('Find & Replace reset working in the background. You will be notified once the process is complete.')

--- a/app/Filament/Resources/CustomPlaylistResource.php
+++ b/app/Filament/Resources/CustomPlaylistResource.php
@@ -11,7 +11,7 @@ use App\Models\CustomPlaylist;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Filament\Resources\Resource;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -22,7 +22,7 @@ use App\Services\EpgCacheService;
 use Filament\Forms\FormsComponent;
 use Illuminate\Support\Facades\Redis;
 
-class CustomPlaylistResource extends Resource
+class CustomPlaylistResource extends FilamentResource
 {
     protected static ?string $model = CustomPlaylist::class;
 

--- a/app/Filament/Resources/CustomPlaylistResource/Pages/EditCustomPlaylist.php
+++ b/app/Filament/Resources/CustomPlaylistResource/Pages/EditCustomPlaylist.php
@@ -5,7 +5,7 @@ namespace App\Filament\Resources\CustomPlaylistResource\Pages;
 use App\Filament\Resources\CustomPlaylistResource;
 use App\Services\EpgCacheService;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\EditRecord;
 
 class EditCustomPlaylist extends EditRecord
@@ -23,13 +23,13 @@ class EditCustomPlaylist extends EditRecord
     {
         $cleared = EpgCacheService::clearPlaylistEpgCacheFile($this->record);
         if ($cleared) {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('EPG File Cache Cleared')
                 ->body('The EPG file cache has been successfully cleared.')
                 ->success()
                 ->send();
         } else {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('EPG File Cache Not Found')
                 ->body('No EPG cache files found.')
                 ->warning()

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/CategoriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/CategoriesRelationManager.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\CustomPlaylistResource\RelationManagers;
 
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -65,7 +65,7 @@ class CategoriesRelationManager extends RelationManager
                     })
                     ->modalWidth('md')
                     ->successNotification(
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Group created')
                             ->body('You can now assign channels to this group from the Channels tab.'),

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -10,7 +10,7 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -21,7 +21,6 @@ use Illuminate\Database\Eloquent\Model;
 use Filament\Tables\Columns\SpatieTagsColumn;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\HtmlString;
 use Spatie\Tags\Tag;
 
 class ChannelsRelationManager extends RelationManager
@@ -115,6 +114,11 @@ class ChannelsRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -123,7 +127,7 @@ class ChannelsRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent'])
                     ->withCount(['failovers'])
                     ->where('is_vod', false); // Only show live channels
             })
@@ -247,7 +251,7 @@ class ChannelsRelationManager extends RelationManager
                             $record->syncTagsWithType([$data['group']], $ownerRecord->uuid);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Added to group')
                             ->body('The selected channels have been added to the custom group.')

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/GroupsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/GroupsRelationManager.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\CustomPlaylistResource\RelationManagers;
 
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -65,7 +65,7 @@ class GroupsRelationManager extends RelationManager
                     })
                     ->modalWidth('md')
                     ->successNotification(
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Group created')
                             ->body('You can now assign channels to this group from the Channels tab.'),

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -7,7 +7,7 @@ use App\Models\Series;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Columns\SpatieTagsColumn;
@@ -105,6 +105,11 @@ class SeriesRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 6, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -112,6 +117,7 @@ class SeriesRelationManager extends RelationManager
             ->filtersTriggerAction(function ($action) {
                 return $action->button()->label('Filters');
             })
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('playlist.parent'))
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
             ->columns($defaultColumns)
@@ -219,7 +225,7 @@ class SeriesRelationManager extends RelationManager
                             $record->syncTagsWithType([$data['category']], $ownerRecord->uuid . '-category');
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Added to category')
                             ->body('The selected series have been added to the custom category.')

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
@@ -10,7 +10,7 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -21,7 +21,6 @@ use Illuminate\Database\Eloquent\Model;
 use Filament\Tables\Columns\SpatieTagsColumn;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\HtmlString;
 use Spatie\Tags\Tag;
 
 class VodRelationManager extends RelationManager
@@ -115,6 +114,11 @@ class VodRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+            ->label('Parent Playlist')
+            ->toggleable()
+            ->sortable();
+
         return $table->persistFiltersInSession()
             ->persistFiltersInSession()
             ->persistSortInSession()
@@ -123,7 +127,7 @@ class VodRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent'])
                     ->withCount(['failovers'])
                     ->where('is_vod', true); // Only show VOD content
             })
@@ -235,7 +239,7 @@ class VodRelationManager extends RelationManager
                             $record->syncTagsWithType([$data['group']], $ownerRecord->uuid);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Added to group')
                             ->body('The selected VOD have been added to the custom group.')

--- a/app/Filament/Resources/EpgChannelResource.php
+++ b/app/Filament/Resources/EpgChannelResource.php
@@ -7,13 +7,13 @@ use App\Filament\Resources\EpgChannelResource\RelationManagers;
 use App\Models\EpgChannel;
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Resources\Resource;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
-class EpgChannelResource extends Resource
+class EpgChannelResource extends FilamentResource
 {
     protected static ?string $model = EpgChannel::class;
 

--- a/app/Filament/Resources/EpgMapResource.php
+++ b/app/Filament/Resources/EpgMapResource.php
@@ -12,8 +12,8 @@ use App\Models\Playlist;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Schema;
 use RyanChandler\FilamentProgressColumn\ProgressColumn;
 
-class EpgMapResource extends Resource
+class EpgMapResource extends FilamentResource
 {
     protected static ?string $model = EpgMap::class;
 
@@ -130,7 +130,7 @@ class EpgMapResource extends Resource
                                 epgMapId: $record->id,
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('EPG mapping started')
                             ->body('The EPG mapping process has been initiated.')
@@ -167,7 +167,7 @@ class EpgMapResource extends Resource
                                     ));
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('EPG mapping started')
                                 ->body('The EPG mapping process has been initiated for the selected mappings.')

--- a/app/Filament/Resources/EpgMapResource/Pages/ListEpgMaps.php
+++ b/app/Filament/Resources/EpgMapResource/Pages/ListEpgMaps.php
@@ -7,7 +7,7 @@ use App\Models\Epg;
 use App\Models\Playlist;
 use Filament\Actions;
 use Filament\Forms;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -34,7 +34,7 @@ class ListEpgMaps extends ListRecords
                             settings: $data['settings'] ?? [],
                         ));
                 })->after(function () {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('EPG to Channel mapping')
                         ->body('Channel mapping started, you will be notified when the process is complete.')

--- a/app/Filament/Resources/EpgResource.php
+++ b/app/Filament/Resources/EpgResource.php
@@ -7,14 +7,14 @@ use App\Enums\Status;
 use App\Filament\Resources\EpgResource\Pages;
 use App\Filament\Resources\EpgResource\RelationManagers;
 use App\Models\Epg;
-use App\Rules\CheckIfUrlOrLocalPath;
+use App\Rules\CheckIfUrlOrLocalPath as CheckIfUrlOrLocalPathRule;
 use App\Services\SchedulesDirectService;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -23,7 +23,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Auth;
 use RyanChandler\FilamentProgressColumn\ProgressColumn;
 
-class EpgResource extends Resource
+class EpgResource extends FilamentResource
 {
     protected static ?string $model = Epg::class;
 
@@ -155,7 +155,7 @@ class EpgResource extends Resource
                             app('Illuminate\Contracts\Bus\Dispatcher')
                                 ->dispatch(new \App\Jobs\ProcessEpgImport($record, force: true));
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('EPG is processing')
                                 ->body('EPG is being processed in the background. Depending on the size of the guide data, this may take a while. You will be notified on completion.')
@@ -179,7 +179,7 @@ class EpgResource extends Resource
                             app('Illuminate\Contracts\Bus\Dispatcher')
                                 ->dispatch(new \App\Jobs\GenerateEpgCache($record->uuid, notify: true));
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('EPG Cache is being generated')
                                 ->body('EPG Cache is being generated in the background. You will be notified when complete.')
@@ -210,7 +210,7 @@ class EpgResource extends Resource
                                 'errors' => null,
                             ]);
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('EPG status reset')
                                 ->body('EPG status has been reset.')
@@ -246,7 +246,7 @@ class EpgResource extends Resource
                                     ->dispatch(new \App\Jobs\ProcessEpgImport($record, force: true));
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Selected EPGs are processing')
                                 ->body('The selected EPGs are being processed in the background. Depending on the size of the guide data, this may take a while.')
@@ -273,7 +273,7 @@ class EpgResource extends Resource
                                     ->dispatch(new \App\Jobs\GenerateEpgCache($record->uuid, notify: true));
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('EPG Cache is being generated for selected EPGs')
                                 ->body('EPG Cache is being generated in the background for the selected EPGs. You will be notified when complete.')
@@ -485,7 +485,7 @@ class EpgResource extends Resource
                                         $password = $get('sd_password');
 
                                         if (!$username || !$password) {
-                                            Notification::make()
+                                            FilamentNotification::make()
                                                 ->danger()
                                                 ->title('Missing credentials')
                                                 ->body('Please enter username and password first')
@@ -496,13 +496,13 @@ class EpgResource extends Resource
                                         try {
                                             $authData = $service->authenticate($username, $password);
 
-                                            Notification::make()
+                                            FilamentNotification::make()
                                                 ->success()
                                                 ->title('Connection successful!')
                                                 ->body("Token expires: " . date('Y-m-d H:i:s', $authData['expires']))
                                                 ->send();
                                         } catch (\Exception $e) {
-                                            Notification::make()
+                                            FilamentNotification::make()
                                                 ->danger()
                                                 ->title('Connection failed')
                                                 ->body($e->getMessage())
@@ -520,7 +520,7 @@ class EpgResource extends Resource
                                         $password = $get('sd_password');
 
                                         if (!$country || !$postalCode || !$username || !$password) {
-                                            Notification::make()
+                                            FilamentNotification::make()
                                                 ->warning()
                                                 ->title('Missing information')
                                                 ->body('Please fill in all required fields first')
@@ -550,14 +550,14 @@ class EpgResource extends Resource
                                                 }
                                             }
 
-                                            Notification::make()
+                                            FilamentNotification::make()
                                                 ->success()
                                                 ->title("Found {$lineupCount} available lineups")
                                                 ->body($lineupList ?: 'No lineups found for your location')
                                                 ->persistent()
                                                 ->send();
                                         } catch (\Exception $e) {
-                                            Notification::make()
+                                            FilamentNotification::make()
                                                 ->danger()
                                                 ->title('Failed to fetch lineups')
                                                 ->body($e->getMessage())
@@ -574,7 +574,7 @@ class EpgResource extends Resource
                                 //         $lineupId = $get('sd_lineup_id');
 
                                 //         if (!$username || !$password || !$lineupId) {
-                                //             Notification::make()
+                                //             FilamentNotification::make()
                                 //                 ->warning()
                                 //                 ->title('Missing information')
                                 //                 ->body('Please enter credentials and select a lineup first')
@@ -586,13 +586,13 @@ class EpgResource extends Resource
                                 //             $authData = $service->authenticate($username, $password);
                                 //             $result = $service->addLineup($authData['token'], $lineupId);
 
-                                //             Notification::make()
+                                //             FilamentNotification::make()
                                 //                 ->success()
                                 //                 ->title('Lineup added successfully!')
                                 //                 ->body("Lineup {$lineupId} has been added to your Schedules Direct account")
                                 //                 ->send();
                                 //         } catch (\Exception $e) {
-                                //             Notification::make()
+                                //             FilamentNotification::make()
                                 //                 ->danger()
                                 //                 ->title('Failed to add lineup')
                                 //                 ->body($e->getMessage())
@@ -624,7 +624,7 @@ class EpgResource extends Resource
                         ->helperText('Enter the URL of the XMLTV guide data. If this is a local file, you can enter a full or relative path. If changing URL, the guide data will be re-imported. Use with caution as this could lead to data loss if the new guide differs from the old one.')
                         ->requiredWithout('uploads')
                         ->required(fn(Get $get): bool => $get('source_type') === EpgSourceType::URL->value && !$get('uploads'))
-                        ->rules([new CheckIfUrlOrLocalPath()])
+                        ->rules([new CheckIfUrlOrLocalPathRule()])
                         ->maxLength(255),
                     Forms\Components\FileUpload::make('uploads')
                         ->label('File')

--- a/app/Filament/Resources/EpgResource/Pages/ViewEpg.php
+++ b/app/Filament/Resources/EpgResource/Pages/ViewEpg.php
@@ -9,7 +9,7 @@ use App\Livewire\EpgViewer;
 use Filament\Actions;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewEpg extends ViewRecord
@@ -41,7 +41,7 @@ class ViewEpg extends ViewRecord
                     app('Illuminate\Contracts\Bus\Dispatcher')
                         ->dispatch(new \App\Jobs\ProcessEpgImport($record, force: true));
                 })->after(function () {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('EPG is processing')
                         ->body('EPG is being processed in the background. The view will update when complete.')
@@ -66,7 +66,7 @@ class ViewEpg extends ViewRecord
                     app('Illuminate\Contracts\Bus\Dispatcher')
                         ->dispatch(new \App\Jobs\GenerateEpgCache($record->uuid, notify: true));
                 })->after(function () {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('EPG Cache is being generated')
                         ->body('EPG Cache is being generated in the background. You will be notified when complete.')

--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -7,22 +7,24 @@ use App\Filament\Resources\GroupResource\RelationManagers;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\Playlist;
-use App\Jobs\SyncPlaylistChildren;
+use App\Filament\Concerns\DisplaysPlaylistMembership;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
-class GroupResource extends Resource
+class GroupResource extends FilamentResource
 {
+    use \App\Filament\BulkActions\HandlesSourcePlaylist;
+    use DisplaysPlaylistMembership;
     protected static ?string $model = Group::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -104,7 +106,9 @@ class GroupResource extends Resource
                     ->toggleable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('playlist.name')
-                    ->numeric()
+                    ->label('Playlist')
+                    ->formatStateUsing(fn($state, Group $record) => self::playlistDisplay($record, 'name_internal'))
+                    ->tooltip(fn(Group $record) => self::playlistTooltip($record, 'name_internal'))
                     ->toggleable()
                     ->sortable(),
                 Tables\Columns\IconColumn::make('is_custom')
@@ -173,7 +177,7 @@ class GroupResource extends Resource
                                 $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Group channels added to custom playlist')
                                 ->body('The groups channels have been added to the chosen custom playlist.')
@@ -201,9 +205,9 @@ class GroupResource extends Resource
                                 'group' => $group->name,
                                 'group_id' => $group->id,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Channels moved to group')
                                 ->body('The group channels have been moved to the chosen group.')
@@ -221,9 +225,9 @@ class GroupResource extends Resource
                             $record->channels()->update([
                                 'enabled' => true,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Group channels enabled')
                                 ->body('The group channels have been enabled.')
@@ -241,9 +245,9 @@ class GroupResource extends Resource
                             $record->channels()->update([
                                 'enabled' => false,
                             ]);
-                            SyncPlaylistChildren::debounce($record->playlist, []);
+                            \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Group channels disabled')
                                 ->body('The groups channels have been disabled.')
@@ -259,7 +263,7 @@ class GroupResource extends Resource
                     Tables\Actions\DeleteAction::make()
                         ->hidden(fn($record) => !$record->is_custom),
                 ])->button()->hiddenLabel()->size('sm'),
-            ], position: Tables\Enums\ActionsPosition::BeforeCells)
+            ], Tables\Enums\ActionsPosition::BeforeCells)
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\BulkAction::make('add')
@@ -295,7 +299,6 @@ class GroupResource extends Resource
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
                             foreach ($records as $record) {
                                 // Sync the channels to the custom playlist
-                                // This will add the channels to the playlist without detaching existing ones
                                 // Prevents duplicates in the playlist
                                 $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
                                 if ($data['category']) {
@@ -303,7 +306,7 @@ class GroupResource extends Resource
                                 }
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Group channels added to custom playlist')
                                 ->body('The groups channels have been added to the chosen custom playlist.')
@@ -337,10 +340,8 @@ class GroupResource extends Resource
                             $group = Group::findOrFail($data['group']);
                             foreach ($records as $record) {
                                 // Update the channels to the new group
-                                // This will change the group and group_id for the channels in the database
-                                // to reflect the new group
                                 if ($group->playlist_id !== $record->playlist_id) {
-                                    Notification::make()
+                                    FilamentNotification::make()
                                         ->warning()
                                         ->title('Warning')
                                         ->body("Cannot move \"{$group->name}\" to \"{$record->name}\" as they belong to different playlists.")
@@ -352,10 +353,10 @@ class GroupResource extends Resource
                                     'group' => $group->name,
                                     'group_id' => $group->id,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Channels moved to group')
                                 ->body('The group channels have been moved to the chosen group.')
@@ -373,10 +374,10 @@ class GroupResource extends Resource
                                 $record->channels()->update([
                                     'enabled' => true,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Selected group channels enabled')
                                 ->body('The selected group channels have been enabled.')
@@ -396,10 +397,10 @@ class GroupResource extends Resource
                                 $record->channels()->update([
                                     'enabled' => false,
                                 ]);
-                                SyncPlaylistChildren::debounce($record->playlist, []);
+                                \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Selected group channels disabled')
                                 ->body('The selected groups channels have been disabled.')

--- a/app/Filament/Resources/GroupResource/Pages/ListGroups.php
+++ b/app/Filament/Resources/GroupResource/Pages/ListGroups.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\GroupResource\Pages;
 
 use App\Filament\Resources\GroupResource;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +25,7 @@ class ListGroups extends ListRecords
                     return $model::create($data);
                 })
                 ->successNotification(
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Group created')
                         ->body('You can now assign channels to this group from the Channels section.'),

--- a/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
+++ b/app/Filament/Resources/GroupResource/Pages/ViewGroup.php
@@ -5,15 +5,16 @@ namespace App\Filament\Resources\GroupResource\Pages;
 use App\Filament\Resources\GroupResource;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
-use App\Jobs\SyncPlaylistChildren;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewGroup extends ViewRecord
 {
+    use \App\Filament\BulkActions\HandlesSourcePlaylist;
+
     protected static string $resource = GroupResource::class;
 
     protected function getHeaderActions(): array
@@ -55,10 +56,10 @@ class ViewGroup extends ViewRecord
                         if ($data['category']) {
                             $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
                         }
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Group channels added to custom playlist')
                             ->body('The groups channels have been added to the chosen custom playlist.')
@@ -86,10 +87,10 @@ class ViewGroup extends ViewRecord
                             'group' => $group->name,
                             'group_id' => $group->id,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channels moved to group')
                             ->body('The group channels have been moved to the chosen group.')
@@ -107,10 +108,10 @@ class ViewGroup extends ViewRecord
                         $record->channels()->update([
                             'enabled' => true,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Group channels enabled')
                             ->body('The group channels have been enabled.')
@@ -128,10 +129,10 @@ class ViewGroup extends ViewRecord
                         $record->channels()->update([
                             'enabled' => false,
                         ]);
-                        SyncPlaylistChildren::debounce($record->playlist, []);
+                        \App\Jobs\SyncPlaylistChildren::debounce($record->playlist, []);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Group channels disabled')
                             ->body('The groups channels have been disabled.')

--- a/app/Filament/Resources/MergedPlaylistResource.php
+++ b/app/Filament/Resources/MergedPlaylistResource.php
@@ -11,7 +11,7 @@ use App\Models\MergedPlaylist;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Filament\Resources\Resource;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -20,7 +20,7 @@ use App\Facades\PlaylistUrlFacade;
 use App\Forms\Components\XtreamApiInfo;
 use App\Services\EpgCacheService;
 
-class MergedPlaylistResource extends Resource
+class MergedPlaylistResource extends FilamentResource
 {
     protected static ?string $model = MergedPlaylist::class;
 

--- a/app/Filament/Resources/MergedPlaylistResource/Pages/EditMergedPlaylist.php
+++ b/app/Filament/Resources/MergedPlaylistResource/Pages/EditMergedPlaylist.php
@@ -5,7 +5,7 @@ namespace App\Filament\Resources\MergedPlaylistResource\Pages;
 use App\Filament\Resources\MergedPlaylistResource;
 use App\Services\EpgCacheService;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\EditRecord;
 
 class EditMergedPlaylist extends EditRecord
@@ -23,13 +23,13 @@ class EditMergedPlaylist extends EditRecord
     {
         $cleared = EpgCacheService::clearPlaylistEpgCacheFile($this->record);
         if ($cleared) {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('EPG File Cache Cleared')
                 ->body('The EPG file cache has been successfully cleared.')
                 ->success()
                 ->send();
         } else {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('EPG File Cache Not Found')
                 ->body('No EPG cache files found.')
                 ->warning()

--- a/app/Filament/Resources/PlaylistAuthResource.php
+++ b/app/Filament/Resources/PlaylistAuthResource.php
@@ -8,12 +8,12 @@ use App\Models\PlaylistAuth;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Filament\Resources\Resource;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
-class PlaylistAuthResource extends Resource
+class PlaylistAuthResource extends FilamentResource
 {
     protected static ?string $model = PlaylistAuth::class;
 

--- a/app/Filament/Resources/PlaylistAuthResource/Pages/ListPlaylistAuths.php
+++ b/app/Filament/Resources/PlaylistAuthResource/Pages/ListPlaylistAuths.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\PlaylistAuthResource\Pages;
 
 use App\Filament\Resources\PlaylistAuthResource;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -24,7 +24,7 @@ class ListPlaylistAuths extends ListRecords
                     return $model::create($data);
                 })
                 ->successNotification(
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Playlist Auth created')
                         ->body('You can now assign Playlists to this Auth.'),

--- a/app/Filament/Resources/PlaylistResource/Pages/EditPlaylist.php
+++ b/app/Filament/Resources/PlaylistResource/Pages/EditPlaylist.php
@@ -8,7 +8,7 @@ use App\Filament\Resources\PlaylistResource\Widgets\ImportProgress;
 use App\Models\Playlist;
 use Filament\Actions;
 use Filament\Forms;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Redis;
 

--- a/app/Filament/Resources/PlaylistResource/Pages/ViewPlaylist.php
+++ b/app/Filament/Resources/PlaylistResource/Pages/ViewPlaylist.php
@@ -7,7 +7,7 @@ use App\Filament\Resources\PlaylistResource\Widgets;
 use App\Models\Playlist;
 use Filament\Actions;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewPlaylist extends ViewRecord

--- a/app/Filament/Resources/PlaylistSyncStatusResource.php
+++ b/app/Filament/Resources/PlaylistSyncStatusResource.php
@@ -7,7 +7,7 @@ use App\Filament\Resources\PlaylistSyncStatusResource\RelationManagers;
 use App\Models\PlaylistSyncStatus;
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Resources\Resource;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
-class PlaylistSyncStatusResource extends Resource
+class PlaylistSyncStatusResource extends FilamentResource
 {
     protected static ?string $model = PlaylistSyncStatus::class;
     protected static ?string $label = 'Sync logs';

--- a/app/Filament/Resources/PostProcessResource.php
+++ b/app/Filament/Resources/PostProcessResource.php
@@ -5,17 +5,17 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\PostProcessResource\Pages;
 use App\Filament\Resources\PostProcessResource\RelationManagers;
 use App\Models\PostProcess;
-use App\Rules\CheckIfUrlOrLocalPath;
+use App\Rules\CheckIfUrlOrLocalPath as CheckIfUrlOrLocalPathRule;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Filament\Resources\Resource;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
-class PostProcessResource extends Resource
+class PostProcessResource extends FilamentResource
 {
     protected static ?string $model = PostProcess::class;
 
@@ -191,7 +191,7 @@ class PostProcessResource extends Resource
                 ->rules(fn(Get $get) => $get('metadata.local') === 'email' ? [
                     'email',
                 ] : [
-                    new CheckIfUrlOrLocalPath(
+                    new CheckIfUrlOrLocalPathRule(
                         urlOnly: $get('metadata.local') === 'url',
                         localOnly: $get('metadata.local') === 'path',
                     ),

--- a/app/Filament/Resources/PostProcessResource/Pages/ListPostProcesses.php
+++ b/app/Filament/Resources/PostProcessResource/Pages/ListPostProcesses.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\PostProcessResource\Pages;
 
 use App\Filament\Resources\PostProcessResource;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -26,7 +26,7 @@ class ListPostProcesses extends ListRecords
                 })
                 ->slideOver()
                 ->successNotification(
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Post Process created')
                         ->body('You can now assign Playlists or EPGs.'),

--- a/app/Filament/Resources/SeriesResource.php
+++ b/app/Filament/Resources/SeriesResource.php
@@ -6,18 +6,18 @@ use App\Facades\LogoFacade;
 use App\Filament\Resources\SeriesResource\Pages;
 use App\Filament\Resources\SeriesResource\RelationManagers;
 use App\Models\Category;
-use App\Models\CustomPlaylist;
 use App\Models\Playlist;
 use App\Models\Series;
-use App\Rules\CheckIfUrlOrLocalPath;
+use App\Filament\Concerns\DisplaysPlaylistMembership;
+use App\Rules\CheckIfUrlOrLocalPath as CheckIfUrlOrLocalPathRule;
 use App\Services\XtreamService;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
@@ -25,9 +25,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Validation\ValidationException;
 
-class SeriesResource extends Resource
+class SeriesResource extends FilamentResource
 {
+    use \App\Filament\BulkActions\HandlesSourcePlaylist;
+    use DisplaysPlaylistMembership;
     protected static ?string $model = Series::class;
 
     protected static ?string $recordTitleAttribute = 'name';
@@ -137,9 +140,11 @@ class SeriesResource extends Resource
                 ->numeric()
                 ->sortable(),
             Tables\Columns\TextColumn::make('playlist.name')
-                ->numeric()
-                ->sortable()
-                ->hidden(fn() => !$showPlaylist),
+                ->label('Playlist')
+                ->hidden(fn() => !$showPlaylist)
+                ->formatStateUsing(fn($state, Series $record) => self::playlistDisplay($record, 'source_series_id'))
+                ->tooltip(fn(Series $record) => self::playlistTooltip($record, 'source_series_id'))
+                ->sortable(),
             Tables\Columns\TextColumn::make('created_at')
                 ->dateTime()
                 ->sortable()
@@ -192,7 +197,7 @@ class SeriesResource extends Resource
                             'category_id' => $category->id,
                         ]);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series moved to category')
                             ->body('The series has been moved to the chosen category.')
@@ -211,7 +216,7 @@ class SeriesResource extends Resource
                                 playlistSeries: $record,
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series is being processed')
                             ->body('You will be notified once complete.')
@@ -231,7 +236,7 @@ class SeriesResource extends Resource
                                 series: $record,
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series .strm files are being synced')
                             ->body('You will be notified once complete.')
@@ -255,55 +260,8 @@ class SeriesResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected series to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Category')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the category you would like to assign to the selected series to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid . '-category')
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->series()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Series added to custom playlist')
-                            ->body('The selected series have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected series to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Series::class, 'series', 'source_series_id', 'series', '-category', 'Custom Category')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move Series to Category')
                     ->form([
@@ -330,7 +288,7 @@ class SeriesResource extends Resource
                             // This will change the category_id for the series in the database
                             // to reflect the new category
                             if ($category->playlist_id !== $record->playlist_id) {
-                                Notification::make()
+                                FilamentNotification::make()
                                     ->warning()
                                     ->title('Warning')
                                     ->body("Cannot move \"{$category->name}\" to \"{$record->name}\" as they belong to different playlists.")
@@ -342,8 +300,9 @@ class SeriesResource extends Resource
                                 'category_id' => $category->id,
                             ]);
                         }
+                        \App\Jobs\SyncPlaylistChildren::debounce($category->playlist, []);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series moved to category')
                             ->body('The category series have been moved to the chosen category.')
@@ -365,7 +324,7 @@ class SeriesResource extends Resource
                                 ));
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series are being processed')
                             ->body('You will be notified once complete.')
@@ -387,7 +346,7 @@ class SeriesResource extends Resource
                                 ));
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('.strm files are being synced for selected series')
                             ->body('You will be notified once complete.')
@@ -408,7 +367,7 @@ class SeriesResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Selected series enabled')
                             ->body('The selected series have been enabled.')
@@ -430,7 +389,7 @@ class SeriesResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Selected series disabled')
                             ->body('The selected series have been disabled.')
@@ -576,7 +535,7 @@ class SeriesResource extends Resource
                                     Forms\Components\TextInput::make('sync_location')
                                         ->label('Series Sync Location')
                                         ->live()
-                                        ->rules([new CheckIfUrlOrLocalPath(localOnly: true, isDirectory: true)])
+                                        ->rules([new CheckIfUrlOrLocalPathRule(localOnly: true, isDirectory: true)])
                                         ->helperText(
                                             fn($get) => !$get('sync_settings.include_series')
                                                 ? 'File location: ' . $get('sync_location') . ($get('sync_settings.include_season') ?? false ? '/Season 01' : '') . '/S01E01 - Episode Title.strm'

--- a/app/Filament/Resources/SeriesResource/Pages/EditSeries.php
+++ b/app/Filament/Resources/SeriesResource/Pages/EditSeries.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\SeriesResource\Pages;
 
 use App\Filament\Resources\SeriesResource;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\EditRecord;
 
 class EditSeries extends EditRecord
@@ -24,7 +24,7 @@ class EditSeries extends EditRecord
                                 playlistSeries: $record,
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series is being processed')
                             ->body('You will be notified once complete.')
@@ -44,7 +44,7 @@ class EditSeries extends EditRecord
                                 series: $record,
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series .strm files are being synced')
                             ->body('You will be notified once complete.')
@@ -65,7 +65,7 @@ class EditSeries extends EditRecord
                         ]);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series episodes enabled')
                             ->body('The series episodes have been enabled.')
@@ -85,7 +85,7 @@ class EditSeries extends EditRecord
                         ]);
                     })->after(function ($livewire) {
                         $livewire->dispatch('refreshRelation');
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Series episodes disabled')
                             ->body('The series episodes have been disabled.')

--- a/app/Filament/Resources/SeriesResource/Pages/ListSeries.php
+++ b/app/Filament/Resources/SeriesResource/Pages/ListSeries.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\SeriesResource\Pages;
 
 use App\Filament\Resources\SeriesResource;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -32,7 +32,7 @@ class ListSeries extends ListRecords
                             importAll: $data['import_all'] ?? false,
                         ));
                 })->after(function () {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Series have been added and are being processed.')
                         ->body('You will be notified when the process is complete.')

--- a/app/Filament/Resources/SeriesResource/RelationManagers/EpisodesRelationManager.php
+++ b/app/Filament/Resources/SeriesResource/RelationManagers/EpisodesRelationManager.php
@@ -9,7 +9,7 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -159,7 +159,7 @@ class EpisodesRelationManager extends RelationManager
                                 ]);
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Selected episodes enabled')
                                 ->body('The selected episodes have been enabled.')
@@ -181,7 +181,7 @@ class EpisodesRelationManager extends RelationManager
                                 ]);
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->success()
                                 ->title('Selected episodes disabled')
                                 ->body('The selected episodes have been disabled.')

--- a/app/Filament/Resources/VodResource.php
+++ b/app/Filament/Resources/VodResource.php
@@ -14,13 +14,13 @@ use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\Group;
 use App\Models\Playlist;
-use App\Rules\CheckIfUrlOrLocalPath;
+use App\Filament\Concerns\DisplaysPlaylistMembership;
+use App\Rules\CheckIfUrlOrLocalPath as CheckIfUrlOrLocalPathRule;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
-use Illuminate\Support\HtmlString;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
+use Filament\Notifications\Notification as FilamentNotification;
+use Filament\Resources\Resource as FilamentResource;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
 use Filament\Tables;
@@ -31,9 +31,12 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
-class VodResource extends Resource
+class VodResource extends FilamentResource
 {
+    use \App\Filament\BulkActions\HandlesSourcePlaylist;
+    use DisplaysPlaylistMembership;
     protected static ?string $model = Channel::class;
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -256,8 +259,10 @@ class VodResource extends Resource
                 ->toggleable(isToggledHiddenByDefault: true)
                 ->sortable(),
             Tables\Columns\TextColumn::make('playlist.name')
+                ->label('Playlist')
                 ->hidden(fn() => !$showPlaylist)
-                ->numeric()
+                ->formatStateUsing(fn($state, Channel $record) => self::playlistDisplay($record, 'source_id'))
+                ->tooltip(fn(Channel $record) => self::playlistTooltip($record, 'source_id'))
                 ->toggleable()
                 ->sortable(),
 
@@ -369,7 +374,7 @@ class VodResource extends Resource
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new \App\Jobs\ProcessVodChannels(channel: $record));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Fetching VOD metadata for channel')
                             ->body('The VOD metadata fetching and processing has been started. You will be notified when it is complete.')
@@ -389,7 +394,7 @@ class VodResource extends Resource
                                 channel: $record,
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('VOD .strm file is being synced now')
                             ->body('You will be notified once complete.')
@@ -414,55 +419,8 @@ class VodResource extends Resource
     {
         return [
             Tables\Actions\BulkActionGroup::make([
-                Tables\Actions\BulkAction::make('add')
-                    ->label('Add to Custom Playlist')
-                    ->form([
-                        Forms\Components\Select::make('playlist')
-                            ->required()
-                            ->live()
-                            ->label('Custom Playlist')
-                            ->helperText('Select the custom playlist you would like to add the selected channel(s) to.')
-                            ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                            ->afterStateUpdated(function (Forms\Set $set, $state) {
-                                if ($state) {
-                                    $set('category', null);
-                                }
-                            })
-                            ->searchable(),
-                        Forms\Components\Select::make('category')
-                            ->label('Custom Group')
-                            ->disabled(fn(Get $get) => !$get('playlist'))
-                            ->helperText(fn(Get $get) => !$get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
-                            ->options(function ($get) {
-                                $customList = CustomPlaylist::find($get('playlist'));
-                                return $customList ? $customList->tags()
-                                    ->where('type', $customList->uuid)
-                                    ->get()
-                                    ->mapWithKeys(fn($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
-                                    ->toArray() : [];
-                            })
-                            ->searchable(),
-                    ])
-                    ->action(function (Collection $records, array $data): void {
-                        $playlist = CustomPlaylist::findOrFail($data['playlist']);
-                        $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $playlist->syncTagsWithType([$data['category']], $playlist->uuid);
-                        }
-                    })->after(function () {
-                        Notification::make()
-                            ->success()
-                            ->title('Channels added to custom playlist')
-                            ->body('The selected channels have been added to the chosen custom playlist.')
-                            ->send();
-                    })
-                    ->hidden(fn() => !$addToCustom)
-                    ->deselectRecordsAfterCompletion()
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-play')
-                    ->modalIcon('heroicon-o-play')
-                    ->modalDescription('Add the selected channel(s) to the chosen custom playlist.')
-                    ->modalSubmitActionLabel('Add now'),
+                self::addToCustomPlaylistBulkAction(Channel::class, 'channels', 'source_id', 'channel(s)', '')
+                    ->hidden(fn () => !$addToCustom),
                 Tables\Actions\BulkAction::make('move')
                     ->label('Move to Group')
                     ->form([
@@ -494,8 +452,9 @@ class VodResource extends Resource
                                 'group_id' => $group->id,
                             ]);
                         }
+                        \App\Jobs\SyncPlaylistChildren::debounce($group->playlist, []);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channels moved to group')
                             ->body('The selected channels have been moved to the chosen group.')
@@ -520,7 +479,7 @@ class VodResource extends Resource
                             }
                         }
 
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title("Fetching VOD metadata for {$count} channel(s)")
                             ->body('The VOD metadata fetching and processing has been started. You will be notified when it is complete.')
@@ -543,7 +502,7 @@ class VodResource extends Resource
                                 ));
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('.strm files are being synced for selected VOD channels')
                             ->body('You will be notified once complete.')
@@ -567,7 +526,7 @@ class VodResource extends Resource
                                 settings: $data['settings'] ?? [],
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('EPG to Channel mapping')
                             ->body('Mapping started, you will be notified when the process is complete.')
@@ -598,7 +557,7 @@ class VodResource extends Resource
                                 'logo_type' => $data['logo_type'],
                             ]);
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Preferred icon updated')
                             ->body('The preferred icon has been updated.')
@@ -693,7 +652,7 @@ class VodResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channels as failover')
                             ->body('The selected channels have been added as failovers.')
@@ -750,7 +709,7 @@ class VodResource extends Resource
                                 channels: $records
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace started')
                             ->body('Find & Replace working in the background. You will be notified once the process is complete.')
@@ -784,7 +743,7 @@ class VodResource extends Resource
                                 channels: $records
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace reset started')
                             ->body('Find & Replace reset working in the background. You will be notified once the process is complete.')
@@ -805,7 +764,7 @@ class VodResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Selected channels enabled')
                             ->body('The selected channels have been enabled.')
@@ -827,7 +786,7 @@ class VodResource extends Resource
                             ]);
                         }
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Selected channels disabled')
                             ->body('The selected channels have been disabled.')
@@ -1428,7 +1387,7 @@ class VodResource extends Resource
                             Forms\Components\TextInput::make('sync_location')
                                 ->label('VOD Sync Location')
                                 ->live()
-                                ->rules([new CheckIfUrlOrLocalPath(localOnly: true, isDirectory: true)])
+                                ->rules([new CheckIfUrlOrLocalPathRule(localOnly: true, isDirectory: true)])
                                 ->helperText(
                                     fn($get) => 'File location: ' . $get('sync_location') . ($get('sync_settings.include_season') ?? false ? '/Group Name' : '') . '/VOD Title.strm'
                                 )

--- a/app/Filament/Resources/VodResource/Pages/ListVod.php
+++ b/app/Filament/Resources/VodResource/Pages/ListVod.php
@@ -12,7 +12,7 @@ use App\Models\Playlist;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Get;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
@@ -92,7 +92,7 @@ class ListVod extends ListRecords
                                 checkResolution: $data['by_resolution'] ?? false, // Sort failovers by resolution, or by playlist (default behavior)
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channel merge started')
                             ->body('Merging channels in the background. You will be notified once the process is complete.')
@@ -120,7 +120,7 @@ class ListVod extends ListRecords
                                 playlistId: $data['playlist_id'] ?? null
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Channel unmerge started')
                             ->body('Unmerging channels in the background. You will be notified once the process is complete.')
@@ -145,7 +145,7 @@ class ListVod extends ListRecords
                                 settings: $data['settings'] ?? [],
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('EPG to Channel mapping')
                             ->body('Channel mapping started, you will be notified when the process is complete.')
@@ -216,7 +216,7 @@ class ListVod extends ListRecords
                                 replace_with: $data['replace_with'] ?? ''
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace started')
                             ->body('Find & Replace working in the background. You will be notified once the process is complete.')
@@ -264,7 +264,7 @@ class ListVod extends ListRecords
                                 column: $data['column'] ?? 'title',
                             ));
                     })->after(function () {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('Find & Replace reset started')
                             ->body('Find & Replace reset working in the background. You will be notified once the process is complete.')

--- a/app/Filament/Widgets/QuickActionsWidget.php
+++ b/app/Filament/Widgets/QuickActionsWidget.php
@@ -6,7 +6,7 @@ use App\Models\SharedStream;
 use App\Services\SharedStreamService;
 use App\Services\StreamMonitorService;
 use Filament\Widgets\Widget;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 
 class QuickActionsWidget extends Widget
 {
@@ -20,14 +20,14 @@ class QuickActionsWidget extends Widget
             $sharedStreamService = app(SharedStreamService::class);
             $result = $sharedStreamService->cleanupInactiveStreams();
             
-            Notification::make()
+            FilamentNotification::make()
                 ->title('Cleanup Completed')
                 ->body("Cleaned up {$result['cleaned_streams']} streams and {$result['cleaned_clients']} clients")
                 ->success()
                 ->send();
                 
         } catch (\Exception $e) {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('Cleanup Failed')
                 ->body($e->getMessage())
                 ->danger()

--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -12,7 +12,7 @@ use App\Models\MergedPlaylist;
 use App\Models\Playlist;
 use App\Services\EpgCacheService;
 use Carbon\Carbon;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -534,12 +534,12 @@ class EpgGenerateController extends Controller
         if (!$filePath) {
             // Send notification
             $error = "Invalid EPG file. Unable to read or download an associated EPG file. Please check the URL or uploaded file and try again.";
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error generating epg data for playlist \"{$playlist->name}\" using EPG \"{$epg->name}\"")
                 ->body($error)
                 ->broadcast($epg->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error generating epg data for playlist \"{$playlist->name}\" using EPG \"{$epg->name}\"")
                 ->body($error)

--- a/app/Jobs/ChannelFindAndReplace.php
+++ b/app/Jobs/ChannelFindAndReplace.php
@@ -4,7 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Channel;
 use App\Models\User;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Database\Eloquent\Collection;
@@ -76,12 +76,12 @@ class ChannelFindAndReplace implements ShouldQueue
         $user = User::find($this->user_id);
 
         // Send notification
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Find & Replace completed')
             ->body("Channel find & replace has completed successfully. {$updated} channels updated.")
             ->broadcast($user);
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Find & Replace completed')
             ->body("Channel find & replace has completed successfully. Operation completed in {$completedInRounded} seconds and updated {$updated} channels.")

--- a/app/Jobs/ChannelFindAndReplaceReset.php
+++ b/app/Jobs/ChannelFindAndReplaceReset.php
@@ -4,7 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Channel;
 use App\Models\User;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Database\Eloquent\Collection;
@@ -98,12 +98,12 @@ class ChannelFindAndReplaceReset implements ShouldQueue
         $completedInRounded = round($completedIn, 2);
         $user = User::find($this->user_id);
 
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Find & Replace reset')
             ->body("Channel find & replace reset has completed successfully. {$totalUpdated} channels updated.")
             ->broadcast($user);
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Find & Replace reset completed')
             ->body("Channel find & replace reset has completed successfully. {$totalUpdated} channels updated in {$completedInRounded} seconds")

--- a/app/Jobs/CopyPlaylist.php
+++ b/app/Jobs/CopyPlaylist.php
@@ -3,7 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Playlist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
@@ -39,7 +39,7 @@ class CopyPlaylist implements ShouldQueue
                 $copied = $this->copyPlaylistToPlaylist($copy);
             } else {
                 $this->failed[] = $playlistId;
-                Notification::make()
+                FilamentNotification::make()
                     ->title('Playlist Copy Error')
                     ->body('A Playlist was not found, it may have been removed before the copy was able to complete.')
                     ->danger()
@@ -48,12 +48,12 @@ class CopyPlaylist implements ShouldQueue
         }
 
         // Send notification
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Playlist Copied')
             ->body("\"{$playlist->name}\" has been copied successfully.")
             ->broadcast($playlist->user);
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Playlist Copied')
             ->body("\"{$playlist->name}\" has been copied successfully to the following playlists: " . implode(', ', $this->copied))

--- a/app/Jobs/CreateBackup.php
+++ b/app/Jobs/CreateBackup.php
@@ -3,7 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\User;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Artisan;
@@ -43,12 +43,12 @@ class CreateBackup implements ShouldQueue
             $user = User::whereIn('email', config('dev.admin_emails'))->first();
             if ($user) {
                 $message = "Backup created successfully";
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title("Backup created")
                     ->body($message)
                     ->broadcast($user);
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title("Backup created")
                     ->body($message)
@@ -62,12 +62,12 @@ class CreateBackup implements ShouldQueue
             $user = User::whereIn('email', config('dev.admin_emails'))->first();
             if ($user) {
                 $message = "Backup create failed: {$e->getMessage()}";
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Backup create failed")
                     ->body("Backup create failed, please check the error logs for details")
                     ->broadcast($user);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Backup create failed")
                     ->body(Str::limit($message, 500))

--- a/app/Jobs/DuplicatePlaylist.php
+++ b/app/Jobs/DuplicatePlaylist.php
@@ -3,7 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Playlist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
@@ -232,7 +232,7 @@ class DuplicatePlaylist implements ShouldQueue
 
             // Send notification
             try {
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title('Playlist Duplicated')
                     ->body("\"{$playlist->name}\" has been duplicated successfully.")
@@ -240,7 +240,7 @@ class DuplicatePlaylist implements ShouldQueue
             } catch (\Throwable $broadcastError) {
                 logger()->warning('Broadcast failed: '.$broadcastError->getMessage());
             }
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Playlist Duplicated')
                 ->body("\"{$playlist->name}\" has been duplicated successfully, new playlist: \"{$newPlaylist->name}\"")
@@ -257,7 +257,7 @@ class DuplicatePlaylist implements ShouldQueue
 
             // Send notification
             try {
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error duplicating \"{$this->playlist->name}\"")
                     ->body('Please view your notifications for details.')
@@ -265,7 +265,7 @@ class DuplicatePlaylist implements ShouldQueue
             } catch (\Throwable $broadcastError) {
                 logger()->warning('Broadcast failed: '.$broadcastError->getMessage());
             }
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error duplicating \"{$this->playlist->name}\"")
                 ->body($e->getMessage())

--- a/app/Jobs/GenerateEpgCache.php
+++ b/app/Jobs/GenerateEpgCache.php
@@ -5,7 +5,7 @@ namespace App\Jobs;
 use App\Enums\Status;
 use App\Models\Epg;
 use App\Services\EpgCacheService;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
@@ -59,7 +59,7 @@ class GenerateEpgCache implements ShouldQueue
         if ($result) {
             if ($this->notify) {
                 $msg = "Cache generated successfully in " . round($duration, 2) . " seconds";
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title("EPG cache created for \"{$epg->name}\"")
                     ->body($msg)
@@ -68,7 +68,7 @@ class GenerateEpgCache implements ShouldQueue
             }
         } else {
             $error = "Failed to generate cache. You can try to run the cache generation again manually from the EPG management page.";
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error creating cache for \"{$epg->name}\"")
                 ->body($error)

--- a/app/Jobs/MapEpgToChannelsComplete.php
+++ b/app/Jobs/MapEpgToChannelsComplete.php
@@ -8,7 +8,7 @@ use App\Models\EpgMap;
 use App\Models\Job;
 use App\Models\Playlist;
 use Carbon\Carbon;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
@@ -64,7 +64,7 @@ class MapEpgToChannelsComplete implements ShouldQueue
         $epg = $this->epg;
         $title = "Completed processing EPG channel mapping";
         $body = "EPG \"{$epg->name}\" channel mapping completed. Mapping took {$completedInRounded} seconds.";
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title($title)->body($body)
             ->broadcast($epg->user)

--- a/app/Jobs/MapPlaylistChannelsToEpg.php
+++ b/app/Jobs/MapPlaylistChannelsToEpg.php
@@ -12,7 +12,7 @@ use App\Models\EpgChannel;
 use App\Models\EpgMap;
 use App\Models\Job;
 use App\Models\Playlist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
@@ -249,12 +249,12 @@ class MapPlaylistChannelsToEpg implements ShouldQueue
                 ->onQueue('import')
                 ->catch(function (Throwable $e) use ($epg, $map) {
                     $error = "Error processing \"{$epg->name}\" mapping: {$e->getMessage()}";
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error processing \"{$epg->name}\" mapping")
                         ->body('Please view your notifications for details.')
                         ->broadcast($epg->user);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error processing \"{$epg->name}\" mapping")
                         ->body($error)
@@ -272,12 +272,12 @@ class MapPlaylistChannelsToEpg implements ShouldQueue
             logger()->error("Error processing \"{$epg->name}\" mapping: {$e->getMessage()}");
 
             // Send notification
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$epg->name}\" mapping")
                 ->body('Please view your notifications for details.')
                 ->broadcast($epg->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$epg->name}\" mapping")
                 ->body($e->getMessage())

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 
 class MergeChannels implements ShouldQueue
 {
@@ -148,7 +148,7 @@ class MergeChannels implements ShouldQueue
     {
         $body = $processed > 0 ? "Merged {$processed} channels successfully." : 'No channels were merged.';
 
-        Notification::make()
+        FilamentNotification::make()
             ->title('Merge complete')
             ->body($body)
             ->success()

--- a/app/Jobs/ProcessEpgImport.php
+++ b/app/Jobs/ProcessEpgImport.php
@@ -12,7 +12,7 @@ use App\Models\Epg;
 use App\Models\Job;
 use App\Services\SchedulesDirectService;
 use Carbon\Carbon;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Str;
@@ -98,12 +98,12 @@ class ProcessEpgImport implements ShouldQueue
 
                     // Send notification
                     $error = "Invalid Schedules Direct credentials. Unable to get results from the API. Please check the credentials and try again.";
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error processing \"{$this->epg->name}\"")
                         ->body('Please view your notifications for details.')
                         ->broadcast($this->epg->user);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error processing \"{$this->epg->name}\"")
                         ->body($error)
@@ -124,7 +124,7 @@ class ProcessEpgImport implements ShouldQueue
                 } else {
                     // Sync the EPG data from Schedules Direct
                     // Notify user we're starting the sync...
-                    Notification::make()
+                    FilamentNotification::make()
                         ->info()
                         ->title('Starting Schedules Direct Data Sync')
                         ->body("Schedules Direct Data Sync started for EPG \"{$epg->name}\".")
@@ -155,7 +155,7 @@ class ProcessEpgImport implements ShouldQueue
                     $completedInRounded = round($completedIn, 2);
 
                     // Notify user of success
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Schedules Direct Data Synced')
                         ->body("Schedules Direct Data Synced successfully for EPG \"{$epg->name}\". Completed in {$completedInRounded} seconds. Now parsing data and generating EPG cache...")
@@ -220,12 +220,12 @@ class ProcessEpgImport implements ShouldQueue
 
                 // Send notification
                 $error = "Invalid EPG file. Unable to read or download your EPG file. Please check the URL or uploaded file and try again.";
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$this->epg->name}\"")
                     ->body('Please view your notifications for details.')
                     ->broadcast($this->epg->user);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$this->epg->name}\"")
                     ->body($error)
@@ -369,12 +369,12 @@ class ProcessEpgImport implements ShouldQueue
                     ->onQueue('import')
                     ->catch(function (Throwable $e) use ($epg) {
                         $error = "Error processing \"{$epg->name}\": {$e->getMessage()}";
-                        Notification::make()
+                        FilamentNotification::make()
                             ->danger()
                             ->title("Error processing \"{$epg->name}\"")
                             ->body('Please view your notifications for details.')
                             ->broadcast($epg->user);
-                        Notification::make()
+                        FilamentNotification::make()
                             ->danger()
                             ->title("Error processing \"{$epg->name}\"")
                             ->body($error)
@@ -394,12 +394,12 @@ class ProcessEpgImport implements ShouldQueue
 
                 // Send notification
                 $error = "Invalid EPG file. Unable to read or download your EPG file. Please check the URL or uploaded file and try again.";
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$this->epg->name}\"")
                     ->body('Please view your notifications for details.')
                     ->broadcast($this->epg->user);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$this->epg->name}\"")
                     ->body($error)
@@ -422,12 +422,12 @@ class ProcessEpgImport implements ShouldQueue
             logger()->error("Error processing \"{$this->epg->name}\": {$e->getMessage()}");
 
             // Send notification
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$this->epg->name}\"")
                 ->body('Please view your notifications for details.')
                 ->broadcast($this->epg->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$this->epg->name}\"")
                 ->body($e->getMessage())

--- a/app/Jobs/ProcessEpgImportComplete.php
+++ b/app/Jobs/ProcessEpgImportComplete.php
@@ -8,7 +8,7 @@ use App\Models\EpgChannel;
 use App\Models\Job;
 use App\Models\User;
 use Carbon\Carbon;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
@@ -43,12 +43,12 @@ class ProcessEpgImportComplete implements ShouldQueue
         $epg = $user->epgs()->find($this->epgId);
 
         // Send notification
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('EPG Synced')
             ->body("\"{$epg->name}\" has been synced successfully.")
             ->broadcast($epg->user);
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('EPG Synced')
             ->body("\"{$epg->name}\" has been synced successfully. Import completed in {$completedInRounded} seconds.")

--- a/app/Jobs/ProcessEpgSDImport.php
+++ b/app/Jobs/ProcessEpgSDImport.php
@@ -6,7 +6,7 @@ use App\Models\Epg;
 use App\Services\SchedulesDirectService;
 use Carbon\Carbon;
 use Exception;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Storage;
@@ -42,7 +42,7 @@ class ProcessEpgSDImport implements ShouldQueue
         $start = now();
         try {
             // Notify user we're starting the sync...
-            Notification::make()
+            FilamentNotification::make()
                 ->info()
                 ->title('Starting Schedules Direct Data Sync')
                 ->body("Schedules Direct Data Sync started for EPG \"{$epg->name}\".")
@@ -73,7 +73,7 @@ class ProcessEpgSDImport implements ShouldQueue
             $completedInRounded = round($completedIn, 2);
 
             // Notify user of success
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Schedules Direct Data Synced')
                 ->body("Schedules Direct Data Synced successfully for EPG \"{$epg->name}\". Completed in {$completedInRounded} seconds. Now parsing data and generating EPG cache...")
@@ -87,12 +87,12 @@ class ProcessEpgSDImport implements ShouldQueue
 
             // Send notification
             $error = "Error: " . $e->getMessage();
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing Schedules Direct Data for EPG \"{$this->epg->name}\"")
                 ->body('Please view your notifications for details.')
                 ->broadcast($this->epg->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing Schedules Direct Data for EPG \"{$this->epg->name}\"")
                 ->body($error)

--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -13,7 +13,7 @@ use App\Models\Playlist;
 use App\Models\SourceGroup;
 use Carbon\Carbon;
 use M3uParser\M3uParser;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Collection;
@@ -148,12 +148,12 @@ class ProcessM3uImport implements ShouldQueue
         logger()->error("Error processing \"{$this->playlist->name}\": $error");
 
         // Send notification
-        Notification::make()
+        FilamentNotification::make()
             ->danger()
             ->title("Error processing \"{$this->playlist->name}\"")
             ->body($message)
             ->broadcast($this->playlist->user);
-        Notification::make()
+        FilamentNotification::make()
             ->danger()
             ->title("Error processing \"{$this->playlist->name}\"")
             ->body($message)
@@ -476,12 +476,12 @@ class ProcessM3uImport implements ShouldQueue
             logger()->error("Error processing \"{$this->playlist->name}\": {$e->getMessage()}");
 
             // Send notification
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$this->playlist->name}\"")
                 ->body('Please view your notifications for details.')
                 ->broadcast($this->playlist->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$this->playlist->name}\"")
                 ->body($e->getMessage())
@@ -762,12 +762,12 @@ class ProcessM3uImport implements ShouldQueue
 
                 // Send notification
                 $error = "Invalid playlist file. Unable to read or download your playlist file. Please check the URL or uploaded file and try again.";
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$playlist->name}\"")
                     ->body('Please view your notifications for details.')
                     ->broadcast($playlist->user);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$playlist->name}\"")
                     ->body($error)
@@ -792,12 +792,12 @@ class ProcessM3uImport implements ShouldQueue
             logger()->error("Error processing \"{$this->playlist->name}\": {$e->getMessage()}");
 
             // Send notification
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$this->playlist->name}\"")
                 ->body('Please view your notifications for details.')
                 ->broadcast($this->playlist->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error processing \"{$this->playlist->name}\"")
                 ->body($e->getMessage())
@@ -903,12 +903,12 @@ class ProcessM3uImport implements ShouldQueue
         if ($this->m3uParser) {
             $errors = $this->m3uParser->getParseErrors();
             if (count($errors) > 0) {
-                Notification::make()
+                FilamentNotification::make()
                     ->warning()
                     ->title('Error(s) detected during parsing')
                     ->body("While parsing the playlist, please check your notifications for details.")
                     ->broadcast($playlist->user);
-                Notification::make()
+                FilamentNotification::make()
                     ->warning()
                     ->title('Error(s) detected during parsing')
                     ->body("There were issues with the following lines, and they will not be imported due to formatting issues: " . implode('; ', $errors))
@@ -968,12 +968,12 @@ class ProcessM3uImport implements ShouldQueue
 
             // Send notification
             $message = "\"{$playlist->name}\" has been preprocessed successfully. You can now select the groups you would like to import and process the playlist again to import your selected groups. Preprocessing completed in {$completedInRounded} seconds.";
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Playlist Preprocessing Completed')
                 ->body($message)
                 ->broadcast($playlist->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Playlist Preprocessing Completed')
                 ->body($message)
@@ -1044,12 +1044,12 @@ class ProcessM3uImport implements ShouldQueue
             ->catch(function (Throwable $e) use ($playlist) {
                 $error = "Error processing \"{$playlist->name}\": {$e->getMessage()}";
                 Log::error($error);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$playlist->name}\"")
                     ->body('Please view your notifications for details.')
                     ->broadcast($playlist->user);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Error processing \"{$playlist->name}\"")
                     ->body($error)

--- a/app/Jobs/ProcessM3uImportComplete.php
+++ b/app/Jobs/ProcessM3uImportComplete.php
@@ -13,7 +13,7 @@ use App\Models\User;
 use App\Services\EpgCacheService;
 use App\Settings\GeneralSettings;
 use Carbon\Carbon;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
@@ -168,7 +168,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                         Job::where('batch_no', $this->batchNo)->delete();
 
                         // Notify the user
-                        Notification::make()
+                        FilamentNotification::make()
                             ->danger()
                             ->title('Playlist Sync Invalidated')
                             ->body($message)
@@ -245,7 +245,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                             'user_agent' => $playlist->user_agent
                         ]);
                         $msg = "\"{$playlist->name}\" EPG was created and is syncing now.";
-                        Notification::make()
+                        FilamentNotification::make()
                             ->success()
                             ->title('EPG found for Playlist')
                             ->body($msg)
@@ -253,7 +253,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                             ->sendToDatabase($playlist->user);
                     } else {
                         $msg = "\"{$playlist->name}\" EPG not found. Playlist was configured to auto-download EPG but no EPG was found using at the following url: \"$epgUrl\"";
-                        Notification::make()
+                        FilamentNotification::make()
                             ->warning()
                             ->title('No EPG found for Playlist')
                             ->body($msg)
@@ -263,7 +263,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                 }
             } catch (\Exception $e) {
                 // Handle any exceptions that occur during EPG creation
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title('EPG Creation Failed')
                     ->body("Failed to create EPG for \"{$playlist->name}\". Error: {$e->getMessage()}")
@@ -286,23 +286,23 @@ class ProcessM3uImportComplete implements ShouldQueue
         // Send notification
         if ($this->maxHit) {
             $limit = config('dev.max_channels');
-            Notification::make()
+            FilamentNotification::make()
                 ->warning()
                 ->title('Playlist Synced with Limit Reached')
                 ->body("\"{$playlist->name}\" has been synced successfully, but the maximum import limit of {$limit} channels was reached.")
                 ->broadcast($playlist->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->warning()
                 ->title('Playlist Synced with Limit Reached')
                 ->body("\"{$playlist->name}\" has been synced successfully, but the maximum import limit of {$limit} channels was reached. Some channels may not have been imported. Import completed in {$completedInRounded} seconds.")
                 ->sendToDatabase($playlist->user);
         } else {
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Playlist Synced')
                 ->body("\"{$playlist->name}\" has been synced successfully.")
                 ->broadcast($playlist->user);
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Playlist Synced')
                 ->body("\"{$playlist->name}\" has been synced successfully. Import completed in {$completedInRounded} seconds.")
@@ -330,7 +330,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                 isNew: $this->isNew,
                 batchNo: $this->batchNo,
             ));
-            Notification::make()
+            FilamentNotification::make()
                 ->info()
                 ->title('Fetching Series Metadata')
                 ->body('Fetching series metadata now. This may take a while depending on how many series you have enabled. Please check back later.')

--- a/app/Jobs/ProcessM3uImportSeries.php
+++ b/app/Jobs/ProcessM3uImportSeries.php
@@ -6,7 +6,7 @@ use Exception;
 use App\Enums\Status;
 use App\Events\SyncCompleted;
 use App\Models\Playlist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -89,12 +89,12 @@ class ProcessM3uImportSeries implements ShouldQueue
                 ->catch(function (Throwable $e) use ($playlist) {
                     $error = "Error processing series sync on \"{$playlist->name}\": {$e->getMessage()}";
                     Log::error($error);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error processing series sync on \"{$playlist->name}\"")
                         ->body('Please view your notifications for details.')
                         ->broadcast($playlist->user);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error processing series sync on \"{$playlist->name}\"")
                         ->body($error)
@@ -119,7 +119,7 @@ class ProcessM3uImportSeries implements ShouldQueue
                 'errors' => $error,
                 'series_progress' => 0,
             ]);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title('Series Sync Failed')
                 ->body("Playlist series sync failed for \"{$this->playlist->name}\". Error: {$error}")

--- a/app/Jobs/ProcessM3uImportSeriesChunk.php
+++ b/app/Jobs/ProcessM3uImportSeriesChunk.php
@@ -6,7 +6,7 @@ use App\Enums\Status;
 use App\Models\Category;
 use App\Models\Playlist;
 use App\Models\Series;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
@@ -64,7 +64,7 @@ class ProcessM3uImportSeriesChunk implements ShouldQueue
         // This is to ensure that the series progress is reset for each import
         if ($this->index === 0) {
             // Notify the user that series import is starting
-            Notification::make()
+            FilamentNotification::make()
                 ->info()
                 ->title('Syncing Series')
                 ->body('Syncing series now. This may take a while depending on the number of series your provider offers.')

--- a/app/Jobs/ProcessM3uImportSeriesComplete.php
+++ b/app/Jobs/ProcessM3uImportSeriesComplete.php
@@ -6,7 +6,7 @@ use App\Enums\Status;
 use App\Events\SyncCompleted;
 use App\Models\Job;
 use App\Models\Playlist;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
@@ -38,7 +38,7 @@ class ProcessM3uImportSeriesComplete implements ShouldQueue
             'series_progress' => 100,
         ]);
         $message = "Series sync completed successfully for playlist \"{$this->playlist->name}\".";
-        Notification::make()
+        FilamentNotification::make()
             ->success()
             ->title('Series Sync Completed')
             ->body($message)

--- a/app/Jobs/ProcessM3uImportSeriesEpisodes.php
+++ b/app/Jobs/ProcessM3uImportSeriesEpisodes.php
@@ -3,7 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Series;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
@@ -47,7 +47,7 @@ class ProcessM3uImportSeriesEpisodes implements ShouldQueue
             } else {
                 $body .= " .strm file sync is not enabled.";
             }
-            Notification::make()
+            FilamentNotification::make()
                 ->success()
                 ->title('Series Sync Completed')
                 ->body($body)

--- a/app/Jobs/ProcessVodChannels.php
+++ b/app/Jobs/ProcessVodChannels.php
@@ -6,7 +6,7 @@ use App\Models\Channel;
 use App\Models\Playlist;
 use App\Services\XtreamService;
 use App\Events\SyncCompleted;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
@@ -93,7 +93,7 @@ class ProcessVodChannels implements ShouldQueue
             } catch (\Exception $e) {
                 // Log the error and continue processing other channels
                 Log::error('Failed to process VOD data for channel ID ' . $channel->id . ': ' . $e->getMessage());
-                Notification::make()
+                FilamentNotification::make()
                     ->title('VOD Processing Error')
                     ->body('Failed to process VOD data for channel: ' . $channel->name . '. Error: ' . $e->getMessage())
                     ->danger()
@@ -127,7 +127,7 @@ class ProcessVodChannels implements ShouldQueue
                 'errors' => null,
             ]);
             Log::info('Completed processing VOD channels for playlist ID ' . $playlist->id);
-            Notification::make()
+            FilamentNotification::make()
                 ->title('VOD Channels Processed')
                 ->body('Successfully processed VOD channels for playlist: ' . $playlist->name)
                 ->success()
@@ -135,7 +135,7 @@ class ProcessVodChannels implements ShouldQueue
                 ->sendToDatabase($playlist->user);
         } else {
             Log::info('Completed processing VOD data for channel ID ' . $this->channel->id);
-            Notification::make()
+            FilamentNotification::make()
                 ->title('VOD Channel Processed')
                 ->body('Successfully processed VOD data for channel: ' . $this->channel->name)
                 ->success()

--- a/app/Jobs/RestoreBackup.php
+++ b/app/Jobs/RestoreBackup.php
@@ -4,7 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Job;
 use App\Models\User;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Artisan;
@@ -56,12 +56,12 @@ class RestoreBackup implements ShouldQueue
             $user = User::whereIn('email', config('dev.admin_emails'))->first();
             if ($user) {
                 $message = "Backup restored successfully - restored: \"$this->backupPath\"";
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title("Backup restored successfully")
                     ->body($message)
                     ->broadcast($user);
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title("Backup restored successfully")
                     ->body($message)
@@ -75,12 +75,12 @@ class RestoreBackup implements ShouldQueue
             $user = User::whereIn('email', config('dev.admin_emails'))->first();
             if ($user) {
                 $message = "Backup restore (\"$this->backupPath\") failed: {$e->getMessage()}";
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Backup restore failed")
                     ->body($message)
                     ->broadcast($user);
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title("Backup restore failed")
                     ->body($message)

--- a/app/Jobs/RunPostProcess.php
+++ b/app/Jobs/RunPostProcess.php
@@ -9,7 +9,7 @@ use App\Models\Epg;
 use App\Models\PostProcess;
 use App\Models\PostProcessLog;
 use App\Settings\GeneralSettings;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Queue\Queueable;
@@ -154,7 +154,7 @@ class RunPostProcess implements ShouldQueue
                     'status' => 'success',
                     'message' => $body,
                 ]);
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title($title)
                     ->body($body)
@@ -196,7 +196,7 @@ class RunPostProcess implements ShouldQueue
                         'status' => 'success',
                         'message' => $body,
                     ]);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title($title)
                         ->body($body)
@@ -212,7 +212,7 @@ class RunPostProcess implements ShouldQueue
                         'status' => 'error',
                         'message' => $body,
                     ]);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title($title)
                         ->body($body)
@@ -272,7 +272,7 @@ class RunPostProcess implements ShouldQueue
                         'status' => 'success',
                         'message' => $body,
                     ]);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title($title)
                         ->body($body)
@@ -289,7 +289,7 @@ class RunPostProcess implements ShouldQueue
                         'status' => 'error',
                         'message' => $body,
                     ]);
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title($title)
                         ->body($body)
@@ -308,12 +308,12 @@ class RunPostProcess implements ShouldQueue
                 'status' => 'error',
                 'message' => $error,
             ]);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error running post processing for \"$name\"")
                 ->body('Please view your notifications for details.')
                 ->broadcast($user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error running post processing for \"$name\"")
                 ->body($error)

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -5,7 +5,7 @@ namespace App\Jobs;
 use App\Facades\ProxyFacade;
 use App\Models\Series;
 use App\Settings\GeneralSettings;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
@@ -50,7 +50,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
             // Check if sync is enabled
             if (!$sync_settings['enabled'] ?? false) {
                 if ($this->notify) {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error sync .strm files for series \"{$series->name}\"")
                         ->body("Sync is not enabled for this series.")
@@ -66,7 +66,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
             // Check if there are any episodes
             if ($episodes->isEmpty()) {
                 if ($this->notify) {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error sync .strm files for series \"{$series->name}\"")
                         ->body("No episodes found for this series. Try processing it first.")
@@ -80,7 +80,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
             $path = rtrim($sync_settings['sync_location'], '/');
             if (!is_dir($path)) {
                 if ($this->notify) {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->danger()
                         ->title("Error sync .strm files for series \"{$series->name}\"")
                         ->body("Sync location \"{$path}\" does not exist.")
@@ -149,7 +149,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
             // Notify the user
             if ($this->notify) {
-                Notification::make()
+                FilamentNotification::make()
                     ->success()
                     ->title("Sync .strm files for series \"{$series->name}\"")
                     ->body("Sync completed for series \"{$series->name}\".")
@@ -157,7 +157,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                     ->sendToDatabase($series->user);
             }
         } catch (\Exception $e) {
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Error sync .strm files for series \"{$series->name}\"")
                 ->body("Error: {$e->getMessage()}")

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -6,7 +6,7 @@ use App\Facades\ProxyFacade;
 use App\Models\Channel;
 use App\Models\Playlist;
 use App\Settings\GeneralSettings;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Collection;
@@ -57,7 +57,7 @@ class SyncVodStrmFiles implements ShouldQueue
                 $path = rtrim($sync_settings['sync_location'], '/');
                 if (!is_dir($path)) {
                     if ($this->notify) {
-                        Notification::make()
+                        FilamentNotification::make()
                             ->danger()
                             ->title("Error sync .strm files for VOD channel \"{$channel->title}\"")
                             ->body("Sync location \"{$path}\" does not exist.")

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 
 class UnmergeChannels implements ShouldQueue
 {
@@ -59,7 +59,7 @@ class UnmergeChannels implements ShouldQueue
 
     protected function sendCompletionNotification()
     {
-        Notification::make()
+        FilamentNotification::make()
             ->title('Unmerge complete')
             ->body('All channels have been unmerged successfully.')
             ->success()

--- a/app/Listeners/BackupFailed.php
+++ b/app/Listeners/BackupFailed.php
@@ -3,7 +3,7 @@
 namespace App\Listeners;
 
 use App\Models\User;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Spatie\Backup\Events\BackupHasFailed;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -18,12 +18,12 @@ class BackupFailed implements ShouldQueue
         if ($user) {
             $exception = $event->exception;
             $message = "Backup failed, error: \"{$exception->getMessage()}\"";
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Backup failed")
                 ->body($message)
                 ->broadcast($user);
-            Notification::make()
+            FilamentNotification::make()
                 ->danger()
                 ->title("Backup failed")
                 ->body($message)

--- a/app/Livewire/BackupDestinationListRecords.php
+++ b/app/Livewire/BackupDestinationListRecords.php
@@ -4,7 +4,7 @@ namespace App\Livewire;
 
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tables;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
@@ -83,7 +83,7 @@ class BackupDestinationListRecords extends Component implements HasForms, HasTab
                             })
                             ->delete();
 
-                        Notification::make()
+                        FilamentNotification::make()
                             ->title(__('filament-spatie-backup::backup.pages.backups.messages.backup_delete_success'))
                             ->success()
                             ->send();
@@ -109,7 +109,7 @@ class BackupDestinationListRecords extends Component implements HasForms, HasTab
                                     ->delete();
                             }
                         })->after(function () {
-                            Notification::make()
+                            FilamentNotification::make()
                                 ->title('Selected backups deleted successfully')
                                 ->success()
                                 ->send();

--- a/app/Livewire/EpgViewer.php
+++ b/app/Livewire/EpgViewer.php
@@ -16,7 +16,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\EditAction;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 use Illuminate\Support\Str;
@@ -70,7 +70,7 @@ class EpgViewer extends Component implements HasForms, HasActions
                 if ($record) {
                     $record->update($data);
 
-                    Notification::make()
+                    FilamentNotification::make()
                         ->success()
                         ->title('Channel updated')
                         ->body('The channel has been successfully updated.')

--- a/app/Livewire/PlaylistEpgUrl.php
+++ b/app/Livewire/PlaylistEpgUrl.php
@@ -3,7 +3,7 @@
 namespace App\Livewire;
 
 use App\Services\EpgCacheService;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Livewire\Component;
 use Illuminate\Database\Eloquent\Model;
 
@@ -26,13 +26,13 @@ class PlaylistEpgUrl extends Component
     {
         $cleared = EpgCacheService::clearPlaylistEpgCacheFile($this->record);
         if ($cleared) {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('EPG File Cache Cleared')
                 ->body('The EPG file cache has been successfully cleared.')
                 ->success()
                 ->send();
         } else {
-            Notification::make()
+            FilamentNotification::make()
                 ->title('EPG File Cache Not Found')
                 ->body('No EPG cache files found.')
                 ->warning()

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -6,7 +6,7 @@ use App\Enums\ChannelLogoType;
 use App\Facades\ProxyFacade;
 use App\Models\Concerns\DispatchesPlaylistSync;
 use App\Services\XtreamService;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Model;
@@ -210,7 +210,7 @@ class Channel extends Model
                 $xtream = XtreamService::make($playlist);
             }
             if (!$xtream) {
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title('VOD metadata sync failed')
                     ->body('Unable to connect to Xtream API provider to get VOD info, unable to fetch metadata.')

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use App\Jobs\SyncSeriesStrmFiles;
 use App\Models\Concerns\DispatchesPlaylistSync;
 use App\Services\XtreamService;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -88,7 +88,7 @@ class Series extends Model
             $xtream = XtreamService::make($playlist);
 
             if (! $xtream) {
-                Notification::make()
+                FilamentNotification::make()
                     ->danger()
                     ->title('Series metadata sync failed')
                     ->body('Unable to connect to Xtream API provider to get series info, unable to fetch metadata.')

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,7 +32,6 @@ use Illuminate\Support\Facades\Storage;
 use Opcodes\LogViewer\Facades\LogViewer;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
-use Illuminate\Support\HtmlString;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;

--- a/app/Services/EpgCacheService.php
+++ b/app/Services/EpgCacheService.php
@@ -14,7 +14,7 @@ use JsonMachine\Items;
 use JsonMachine\JsonDecoder\ExtJsonDecoder;
 use Filament\Forms;
 use Filament\Actions;
-use Filament\Notifications\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tables;
 use XMLReader;
 
@@ -842,12 +842,12 @@ class EpgCacheService
                                 ->action(function ($record, $state) {
                                     $status = self::clearPlaylistEpgCacheFile($record);
                                     if ($status) {
-                                        Notification::make()
+                                        FilamentNotification::make()
                                             ->title('Cache Cleared')
                                             ->success()
                                             ->send();
                                     } else {
-                                        Notification::make()
+                                        FilamentNotification::make()
                                             ->title('File not yet cached')
                                             ->warning()
                                             ->send();
@@ -867,7 +867,7 @@ class EpgCacheService
                 if ($url) {
                     redirect($url);
                 } else {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->title('Download URL not available')
                         ->danger()
                         ->send();
@@ -916,12 +916,12 @@ class EpgCacheService
                                 ->action(function ($record, $state) {
                                     $status = self::clearPlaylistEpgCacheFile($record);
                                     if ($status) {
-                                        Notification::make()
+                                        FilamentNotification::make()
                                             ->title('Cache Cleared')
                                             ->success()
                                             ->send();
                                     } else {
-                                        Notification::make()
+                                        FilamentNotification::make()
                                             ->title('File not yet cached')
                                             ->warning()
                                             ->send();
@@ -941,7 +941,7 @@ class EpgCacheService
                 if ($url) {
                     redirect($url);
                 } else {
-                    Notification::make()
+                    FilamentNotification::make()
                         ->title('Download URL not available')
                         ->danger()
                         ->send();


### PR DESCRIPTION
## Summary
- display parent playlist name plus number of additional playlists for channels, series, VOD items, categories, and groups
- add DisplaysPlaylistMembership trait to consolidate playlist lookup and tooltip rendering
- remove redundant playlist sync dispatch in channel move-to-group action
- reference HandlesSourcePlaylist trait via fully qualified name to avoid import collisions
- remove redundant SyncPlaylistChildren imports from resources and use fully qualified calls
- alias Filament base Resource as FilamentResource across all resources to avoid name collisions
- drop redundant HtmlString imports to rely on Laravel's global alias
- alias Playlist resource pages namespace to PlaylistPages to prevent collisions
- alias Playlist model as PlaylistModel within PlaylistResource to avoid class name conflicts
- alias CheckIfUrlOrLocalPath validation rule as CheckIfUrlOrLocalPathRule across Filament resources
- fix unmatched parentheses in GroupResource bulk actions
- fix GroupResource parse error by removing named argument in actions call

## Testing
- `composer dump-autoload`
- `php -l app/Filament/Resources/PlaylistResource.php app/Filament/Resources/VodResource.php app/Filament/Resources/EpgResource.php app/Filament/Pages/Preferences.php app/Filament/Resources/PostProcessResource.php app/Filament/Resources/SeriesResource.php`
- `php -l app/Filament/Resources/GroupResource.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcea88474c8321b04398f7e2aeaf50