### PR TITLE
fix: resolve syntax issues in Filament resources

### DIFF
--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -153,6 +153,7 @@ class GroupResource extends FilamentResource
                                 ->select('id', 'playlist_id', 'source_id', 'title')
                                 ->get(),
                         ])
+                    )
                         ->action(function ($record, array $data): void {
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
                             $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
@@ -262,6 +263,7 @@ class GroupResource extends FilamentResource
                                 ->select('id', 'playlist_id', 'source_id', 'title')
                                 ->get(),
                         ])
+                    )
                         ->action(function (Collection $records, array $data): void {
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
                             foreach ($records as $record) {

--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -35,21 +35,13 @@ use App\Livewire\XtreamApiInfo;
 use App\Models\Category;
 use App\Models\Playlist;
 use App\Models\SourceGroup;
-use App\Rules\CheckIfUrlOrLocalPath;
 use App\Services\EpgCacheService;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
-use Filament\Resources\Resource;
-use Filament\Tables;
-use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Schema;
-use RyanChandler\FilamentProgressColumn\ProgressColumn;
 
 class PlaylistResource extends FilamentResource
 {


### PR DESCRIPTION
## Summary
- close unbalanced parentheses in GroupResource addToCustomPlaylist methods
- remove duplicate Filament imports in PlaylistResource

## Testing
- `php -l app/Filament/Resources/GroupResource.php`
- `php -l app/Filament/Resources/ChannelResource.php`
- `php -l app/Filament/Resources/VodResource.php`
- `php -l app/Filament/Resources/SeriesResource.php`
- `php -l app/Filament/Resources/PlaylistResource.php`
- `php artisan test` *(fails: Pusher constructor dependency check)*

------
https://chatgpt.com/codex/tasks/task_e_68c01c39918c83219b3b7bed2c3f5467