### PR TITLE
fix: add missing brace to GroupResource

### DIFF
--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class GroupResource extends FilamentResource
-
+{
     use \App\Filament\BulkActions\HandlesSourcePlaylist;
     use DisplaysPlaylistMembership;
     protected static ?string $model = Group::class;


### PR DESCRIPTION
## Summary
- fix syntax error in GroupResource by adding class opening brace

## Testing
- `php -l app/Filament/Resources/GroupResource.php`
- `php artisan test` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b3551eb48321988876208b26f48f