### PR TITLE
Fix missing CustomPlaylist import in GroupResource

### DIFF
--- a/app/Filament/Resources/GroupResource.php
+++ b/app/Filament/Resources/GroupResource.php
@@ -4,7 +4,9 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\GroupResource\Pages;
 use App\Filament\Resources\GroupResource\RelationManagers;
+use App\Models\Channel;
 use App\Models\Group;
+use App\Models\CustomPlaylist;
 use App\Models\Playlist;
 use App\Filament\Concerns\DisplaysPlaylistMembership;
 use Filament\Forms;


### PR DESCRIPTION
## Summary
- fix missing `Channel` and `CustomPlaylist` imports in `GroupResource`

## Testing
- `./vendor/bin/pest` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c25147bc832185f861646d6291e9