### PR TITLE
Handle series name field in selection queries

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -5,6 +5,7 @@ namespace App\Filament\BulkActions;
 use App\Models\CustomPlaylist;
 use App\Models\Playlist;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Filament\Forms;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
@@ -188,11 +189,22 @@ trait HandlesSourcePlaylist
                                     ->label('View affected items')
                                     ->modalHeading("Items in {$parentName} ↔ {$childName}")
                                     ->form(function () use ($group, $pairKey, $modelClass, $sourceKey, $selectedIds) {
+                                        $instance = new $modelClass();
+                                        $table = $instance->getTable();
+
+                                        $select = ['id'];
+                                        if (Schema::hasColumn($table, 'title')) {
+                                            $select[] = 'title';
+                                        }
+                                        if (Schema::hasColumn($table, 'name')) {
+                                            $select[] = 'name';
+                                        }
+
                                         $records = $modelClass::query()
                                             ->whereIn('id', $selectedIds)
                                             ->whereIn('playlist_id', [$group['parent_id'], $group['child_id']])
                                             ->whereIn($sourceKey, $group['source_ids'])
-                                            ->select('id', 'title', 'name')
+                                            ->select($select)
                                             ->get();
 
                                         return [

--- a/app/Filament/Pages/StreamingChannelStats.php
+++ b/app/Filament/Pages/StreamingChannelStats.php
@@ -126,7 +126,7 @@ class StreamingChannelStats extends Page
                 $model = Episode::find($actualStreamingModelId);
                 $itemLogo = $model ? ($model->cover ?? null) : null;
                 if ($model && $model->series) {
-                    $itemName = $model->series->title . " - S" . $model->season_num . "E" . $model->episode_num . " - " . $model->title;
+                    $itemName = $model->series->name . " - S" . $model->season_num . "E" . $model->episode_num . " - " . $model->title;
                 } elseif ($model) {
                     $itemName = "Ep. " . $model->title;
                 } else {

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -123,7 +123,7 @@ class CategoryResource extends FilamentResource
                         ->label('Add to Custom Playlist')
                         ->form(function (Category $record) use (&$sourcePlaylistData) {
                             $seriesRecords = $record->series()
-                                ->select('id', 'playlist_id', 'source_series_id', 'title', 'name')
+                                ->select('id', 'playlist_id', 'source_series_id', 'name')
                                 ->get();
 
                             $form = [
@@ -168,7 +168,7 @@ class CategoryResource extends FilamentResource
                         })
                         ->action(function (Category $record, array $data) use (&$sourcePlaylistData): void {
                             $seriesRecords = $record->series()
-                                ->select('id', 'playlist_id', 'source_series_id', 'title', 'name')
+                                ->select('id', 'playlist_id', 'source_series_id', 'name')
                                 ->get();
 
                             $seriesRecords = self::mapRecordsToSourcePlaylist(
@@ -318,7 +318,7 @@ class CategoryResource extends FilamentResource
                         ->form(function (Collection $records) use (&$sourcePlaylistData) {
                             $seriesRecords = Series::query()
                                 ->whereIn('category_id', $records->pluck('id'))
-                                ->select('id', 'playlist_id', 'source_series_id', 'title', 'name')
+                                ->select('id', 'playlist_id', 'source_series_id', 'name')
                                 ->get();
 
                             $form = [
@@ -362,7 +362,7 @@ class CategoryResource extends FilamentResource
                         ->action(function (Collection $records, array $data) use (&$sourcePlaylistData): void {
                             $seriesRecords = Series::query()
                                 ->whereIn('category_id', $records->pluck('id'))
-                                ->select('id', 'playlist_id', 'source_series_id', 'title', 'name')
+                                ->select('id', 'playlist_id', 'source_series_id', 'name')
                                 ->get();
 
                             $seriesRecords = self::mapRecordsToSourcePlaylist(

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -197,9 +197,8 @@ class SeriesRelationManager extends RelationManager
                                 return $options;
                             })
                             ->getOptionLabelFromRecordUsing(function ($record) {
-                                $displayTitle = $record->title_custom ?: $record->title;
+                                $displayTitle = $record->name;
                                 $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
-                                $options[$record->id] = "{$displayTitle} [{$playlistName}]";
 
                                 return "{$displayTitle} [{$playlistName}]";
                             }),


### PR DESCRIPTION
## Summary
- remove non-existent `title` column from series selections
- skip `title` column in source playlist helper when it doesn't exist
- replace remaining series `title` references with `name`

## Testing
- `APP_ENV=testing BROADCAST_CONNECTION=log php artisan test` *(fails: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c81a09a88321803a53ede7cdcd92