### PR TITLE
Order parent playlists before children in listings

### DIFF
--- a/app/Filament/Concerns/DisplaysPlaylistMembership.php
+++ b/app/Filament/Concerns/DisplaysPlaylistMembership.php
@@ -4,6 +4,7 @@ namespace App\Filament\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
 
 trait DisplaysPlaylistMembership
 {
@@ -13,11 +14,22 @@ trait DisplaysPlaylistMembership
             return collect([$record->playlist?->name])->filter();
         }
 
-        return $record->newQuery()
-            ->where('user_id', $record->user_id)
-            ->where($sourceKey, $record->{$sourceKey})
-            ->with('playlist')
-            ->get()
+        $table = $record->getTable();
+
+        $query = $record->newQuery()
+            ->select("{$table}.*")
+            ->where("{$table}.user_id", $record->user_id)
+            ->where("{$table}.{$sourceKey}", $record->{$sourceKey})
+            ->with('playlist');
+
+        if (Schema::hasColumn('playlists', 'parent_id')) {
+            $query->join('playlists', "{$table}.playlist_id", '=', 'playlists.id')
+                ->orderByRaw('COALESCE(playlists.parent_id, playlists.id), playlists.parent_id IS NOT NULL, playlists.id');
+        } else {
+            $query->orderBy("{$table}.playlist_id");
+        }
+
+        return $query->get()
             ->pluck('playlist.name')
             ->filter();
     }

--- a/tests/Unit/DisplaysPlaylistMembershipTest.php
+++ b/tests/Unit/DisplaysPlaylistMembershipTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use App\Models\Playlist;
+use App\Models\Group;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\Model;
+use App\Filament\Concerns\DisplaysPlaylistMembership;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+class DisplaysPlaylistMembershipTestHelper
+{
+    use DisplaysPlaylistMembership;
+
+    public static function names(Model $record, string $sourceKey)
+    {
+        return self::getPlaylistNames($record, $sourceKey);
+    }
+
+    public static function display(Model $record, string $sourceKey)
+    {
+        return self::playlistDisplay($record, $sourceKey);
+    }
+}
+
+it('lists parent playlists before children', function () {
+    $user = User::factory()->create();
+
+    $parent = Playlist::factory()->for($user)->create(['name' => 'Parent']);
+    $child = Playlist::factory()->for($user)->create([
+        'name' => 'Child',
+        'parent_id' => $parent->id,
+    ]);
+
+    Group::withoutEvents(fn() => Group::factory()->for($user)->for($parent)->create(['name_internal' => 'group']));
+    $group = Group::withoutEvents(fn() => Group::factory()->for($user)->for($child)->create(['name_internal' => 'group']));
+
+    $names = DisplaysPlaylistMembershipTestHelper::names($group, 'name_internal');
+
+    expect($names->all())->toBe(['Parent', 'Child']);
+    expect(DisplaysPlaylistMembershipTestHelper::display($group, 'name_internal'))->toBe('Parent +1');
+});


### PR DESCRIPTION
## Summary
- Order playlist names so parents appear before children when displaying memberships
- Add unit test verifying parent playlists are listed before child playlists

## Testing
- `vendor/bin/pest` *(fails: SQLSTATE[HY000]: General error: 1 no such table: users)*
- `vendor/bin/pest tests/Unit/DisplaysPlaylistMembershipTest.php` *(fails: SQLSTATE[HY000]: General error: 11 database disk image is malformed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e072a0d0832197927e881d75b292