### PR TITLE
Allow selecting parent playlist for channels in custom playlists

### DIFF
--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -112,8 +112,10 @@ class ChannelsRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
-        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
-            ->label('Parent Playlist')
+        $defaultColumns[] = Tables\Columns\SelectColumn::make('custom_playlist_id')
+            ->label('Playlist')
+            ->options(fn (Channel $record) => $record->customPlaylists->pluck('name', 'id'))
+            ->disabled(fn (Channel $record): bool => $record->customPlaylists->count() <= 1)
             ->toggleable()
             ->sortable();
 
@@ -125,7 +127,7 @@ class ChannelsRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist.parent'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent', 'customPlaylists'])
                     ->withCount(['failovers'])
                     ->where('is_vod', false); // Only show live channels
             })

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -104,7 +104,7 @@ class SeriesRelationManager extends RelationManager
         array_splice($defaultColumns, 6, 0, [$groupColumn]);
 
         $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
-            ->label('Parent Playlist')
+            ->label('Playlist')
             ->toggleable()
             ->sortable();
 

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
@@ -112,8 +112,10 @@ class VodRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
-        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
-            ->label('Parent Playlist')
+        $defaultColumns[] = Tables\Columns\SelectColumn::make('custom_playlist_id')
+            ->label('Playlist')
+            ->options(fn (Channel $record) => $record->customPlaylists->pluck('name', 'id'))
+            ->disabled(fn (Channel $record): bool => $record->customPlaylists->count() <= 1)
             ->toggleable()
             ->sortable();
 
@@ -125,7 +127,7 @@ class VodRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist.parent'])
+                $query->with(['tags', 'epgChannel', 'playlist.parent', 'customPlaylists'])
                     ->withCount(['failovers'])
                     ->where('is_vod', true); // Only show VOD content
             })


### PR DESCRIPTION
## Summary
- show parent playlist selector for channels and VOD entries in custom playlists
- disable parent playlist selector when channel only belongs to one playlist
- rename column title from "Parent Playlist" to "Playlist"

## Testing
- `vendor/bin/pest` *(fails: Cannot use Filament\\Tables as Tables because the name is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68c0eaa237d4832187a564801a30050c