### PR TITLE
feat: allow item-specific playlist selection in custom playlist bulk action

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -9,6 +9,7 @@ use Filament\Forms;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Set;
+use Filament\Forms\Get;
 use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tables;
 use Illuminate\Support\Collection;
@@ -77,41 +78,53 @@ trait HandlesSourcePlaylist
 
         $rows->groupBy('source_id')
             ->each(function ($group, $sourceId) use (&$groups, $playlistNames) {
-                $ids        = $group->pluck('playlist_id')->unique();
-                $parentMap  = $group->mapWithKeys(fn ($row) => [$row->playlist_id => $row->parent_id]);
+                // Map playlist IDs to their parent IDs for this source
+                $parentMap = $group->mapWithKeys(fn ($row) => [$row->playlist_id => $row->parent_id]);
 
-                if ($ids->count() <= 1) {
-                    return;
-                }
-
-                foreach ($ids as $id) {
-                    $parentId = $parentMap[$id] ?? null;
-
-                    if ($parentId && $ids->contains($parentId)) {
-                        $pairKey = $parentId . '-' . $id;
-
-                        $groups[$pairKey] ??= [
-                            'parent_id'      => $parentId,
-                            'child_id'       => $id,
-                            'playlists'      => collect($playlistNames->only([$parentId, $id])),
-                            'source_ids'     => [],
-                            'composite_keys' => [],
-                        ];
-
-                        $groups[$pairKey]['source_ids'][]     = $sourceId;
-                        $groups[$pairKey]['composite_keys'][] = $id . ':' . $sourceId;
-                        $groups[$pairKey]['composite_keys'][] = $parentId . ':' . $sourceId;
+                // Identify parent playlists that also contain the source alongside any children
+                $parentMap->unique()->filter()->each(function ($parentId) use ($parentMap, $sourceId, &$groups, $playlistNames) {
+                    // Parent must itself contain the source
+                    if (! $parentMap->has($parentId)) {
+                        return;
                     }
-                }
+
+                    // Collect all children of this parent containing the source
+                    $childIds = $parentMap
+                        ->filter(fn ($pid) => $pid === $parentId)
+                        ->keys()
+                        ->reject(fn ($id) => $id === $parentId)
+                        ->unique();
+
+                    if ($childIds->isEmpty()) {
+                        return;
+                    }
+
+                    $childKey = $childIds->sort()->join('-');
+                    $groupKey = $parentId . '-' . $childKey;
+
+                    $groups[$groupKey] ??= [
+                        'parent_id'      => $parentId,
+                        'child_ids'      => $childIds->values()->all(),
+                        'playlists'      => collect($playlistNames->only(array_merge([$parentId], $childIds->all()))),
+                        'source_ids'     => [],
+                        'composite_keys' => [],
+                    ];
+
+                    $groups[$groupKey]['source_ids'][] = $sourceId;
+
+                    foreach (array_merge([$parentId], $childIds->all()) as $id) {
+                        $groups[$groupKey]['composite_keys'][] = $id . ':' . $sourceId;
+                    }
+                });
             });
 
         $duplicateGroups = collect($groups);
 
         // Map composite playlist & source IDs to their parent-child pair
         $sourceToGroup = $duplicateGroups
-            ->flatMap(fn ($group, $pairKey) => collect($group['composite_keys'])
+            ->flatMap(fn ($group, $groupKey) => collect($group['composite_keys'])
                 ->unique()
-                ->mapWithKeys(fn ($key) => [$key => $pairKey]));
+                ->mapWithKeys(fn ($key) => [$key => $groupKey]));
 
         $needsSourcePlaylist = $duplicateGroups->isNotEmpty();
 
@@ -178,18 +191,51 @@ trait HandlesSourcePlaylist
 
         $fields = [];
 
-        foreach ($duplicateGroups as $pairKey => $group) {
+        foreach ($duplicateGroups as $groupKey => $group) {
             $parentName = $group['playlists'][$group['parent_id']];
-            $childName  = $group['playlists'][$group['child_id']];
+            $childNames = $group['playlists']->except($group['parent_id'])->values()->implode(', ');
+            $label      = $childNames ? "{$parentName} / {$childNames}" : $parentName;
 
-            $fields[] = Forms\Components\Fieldset::make('These items appear in synced playlists.')
+            $fields[] = Forms\Components\Fieldset::make($label)
                 ->schema([
-                    Forms\Components\Select::make("source_playlists.{$pairKey}")
-                        ->label('Use items from:')
-                        ->options($group['playlists']->toArray())
-                        ->placeholder('Choose source playlist')
+                    Forms\Components\Select::make("source_playlists.{$groupKey}")
+                        ->label('Which playlist do you want to add from?')
+                        ->options(fn (Get $get) => self::availablePlaylistsForGroup(
+                            $get('playlist'),
+                            $group,
+                            $relation,
+                            $sourceKey
+                        )->toArray())
+                        ->placeholder('Choose playlist')
                         ->searchable()
-                        ->required(),
+                        ->live()
+                        ->reactive(),
+                    Actions::make([
+                        Action::make("items_{$groupKey}")
+                            ->label('View Affected Items')
+                            ->form(function (Get $get) use ($group, $groupKey, $relation, $sourceKey) {
+                                $existing = $get("source_playlist_items.{$groupKey}") ?? [];
+                                $default  = $get("source_playlists.{$groupKey}");
+
+                                return collect($group['source_ids'])->map(function ($sourceId) use ($group, $existing, $default, $relation, $sourceKey) {
+                                    return Forms\Components\Select::make("items.{$sourceId}")
+                                        ->label((string) $sourceId)
+                                        ->options(fn (Get $get) => self::availablePlaylistsForGroup(
+                                            $get('playlist'),
+                                            $group,
+                                            $relation,
+                                            $sourceKey
+                                        )->toArray())
+                                        ->placeholder('Choose playlist')
+                                        ->default($existing[$sourceId] ?? $default)
+                                        ->searchable()
+                                        ->reactive();
+                                })->toArray();
+                            })
+                            ->action(function (array $formData, Set $set) use ($groupKey) {
+                                $set("source_playlist_items.{$groupKey}", $formData['items'] ?? []);
+                            }),
+                    ])->columnSpanFull(),
                 ]);
         }
 
@@ -229,25 +275,67 @@ trait HandlesSourcePlaylist
         [$duplicateGroups, $needsSourcePlaylist, $recordSourceIds, $sourceToGroup] = $sourcePlaylistData;
 
         if ($needsSourcePlaylist) {
-            $selected = collect($data['source_playlists'] ?? []);
+            $groupSelections = collect($data['source_playlists'] ?? []);
+            $itemSelections  = collect($data['source_playlist_items'] ?? []);
 
-            foreach ($duplicateGroups as $pairKey => $group) {
-                if (! $selected->has($pairKey)) {
+            $sourceAssignments = collect();
+
+            foreach ($duplicateGroups as $groupKey => $group) {
+                $groupChoice = $groupSelections->get($groupKey);
+                $items       = collect($itemSelections->get($groupKey) ?? []);
+
+                if ($groupChoice && ! $group['playlists']->has($groupChoice)) {
                     throw ValidationException::withMessages([
-                        'source_playlists' => 'Please select a source playlist for each duplicated group.',
+                        'source_playlists' => 'Invalid playlist selection.',
                     ]);
+                }
+
+                foreach ($items as $playlistId) {
+                    if ($playlistId && ! $group['playlists']->has($playlistId)) {
+                        throw ValidationException::withMessages([
+                            'source_playlists' => 'Invalid playlist selection.',
+                        ]);
+                    }
+                }
+
+                if (! $groupChoice && $items->filter()->count() !== count($group['source_ids'])) {
+                    throw ValidationException::withMessages([
+                        'source_playlists' => 'Please select a playlist for each item or choose one at the group level.',
+                    ]);
+                }
+
+                foreach ($group['source_ids'] as $sourceId) {
+                    $chosen = $items[$sourceId] ?? $groupChoice;
+
+                    if ($sourceAssignments->has($sourceId)) {
+                        $existing = $sourceAssignments[$sourceId];
+
+                        if ($chosen && $existing && $chosen !== $existing) {
+                            throw ValidationException::withMessages([
+                                'source_playlists' => 'Conflicting playlist selections were provided for the same item.',
+                            ]);
+                        }
+
+                        if ($chosen) {
+                            $sourceAssignments[$sourceId] = $chosen;
+                        }
+                    } else {
+                        $sourceAssignments[$sourceId] = $chosen;
+                    }
                 }
             }
 
+            $playlistIds = $sourceAssignments->values()->filter()->unique();
+
             $sourceMaps = $modelClass::query()
-                ->whereIn('playlist_id', $selected->values())
+                ->whereIn('playlist_id', $playlistIds)
                 ->whereIn($sourceKey, $recordSourceIds)
                 ->select('id', 'playlist_id', $sourceKey)
                 ->get()
                 ->groupBy('playlist_id')
                 ->map->keyBy($sourceKey);
 
-            $records = $records->map(function ($record) use ($selected, $sourceMaps, $sourceToGroup, $sourceKey) {
+            $records = $records->map(function ($record) use ($sourceAssignments, $sourceMaps, $sourceToGroup, $sourceKey) {
                 $sourceId  = $record->$sourceKey;
                 $composite = $record->playlist_id . ':' . $sourceId;
 
@@ -255,8 +343,7 @@ trait HandlesSourcePlaylist
                     return $record;
                 }
 
-                $pairKey    = $sourceToGroup[$composite];
-                $playlistId = $selected[$pairKey] ?? null;
+                $playlistId = $sourceAssignments[$sourceId] ?? null;
 
                 return $playlistId && isset($sourceMaps[$playlistId][$sourceId])
                     ? $sourceMaps[$playlistId][$sourceId]
@@ -309,7 +396,14 @@ trait HandlesSourcePlaylist
                         ->label('Custom Playlist')
                         ->helperText("Select the custom playlist you would like to add the selected {$itemLabel} to.")
                         ->options(CustomPlaylist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                        ->afterStateUpdated(fn (Set $set, $state) => $state ? $set('category', null) : null)
+                        ->afterStateUpdated(function (Set $set, $state) {
+                            $set('source_playlists', []);
+                            $set('source_playlist_items', []);
+
+                            if ($state) {
+                                $set('category', null);
+                            }
+                        })
                         ->searchable(),
                     Forms\Components\Select::make('category')
                         ->label($categoryLabel)

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}
+

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,6 +13,26 @@
 
 pest()->extend(Tests\TestCase::class);
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
+use App\Jobs\SyncPlaylistChildren;
+
+uses(RefreshDatabase::class)->in('Feature', 'Unit');
+
+beforeEach(function () {
+    Bus::fake();
+    Queue::fake();
+    Config::set('cache.default', 'array');
+    Config::set('queue.default', 'sync');
+    // Prevent static debounce dispatches from running
+    if (! class_exists('\Mockery')) {
+        return;
+    }
+    \Mockery::mock('alias:'.SyncPlaylistChildren::class)->shouldReceive('debounce');
+});
+
 /*
 |--------------------------------------------------------------------------
 | Expectations

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,10 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
+// Use the CreatesApplication trait defined within the Tests namespace
+use Tests\CreatesApplication;
+
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }

--- a/tests/Unit/HandlesSourcePlaylistTest.php
+++ b/tests/Unit/HandlesSourcePlaylistTest.php
@@ -1,0 +1,373 @@
+<?php
+
+use App\Filament\BulkActions\HandlesSourcePlaylist;
+use App\Models\{CustomPlaylist, Group, Playlist, User};
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+class TestChannel extends Model
+{
+    protected $table = 'channels';
+    protected $guarded = [];
+    public $timestamps = true;
+}
+
+class HandlesSourcePlaylistTestClass
+{
+    use HandlesSourcePlaylist;
+
+    public static function data(Collection $records, string $relation, string $sourceKey)
+    {
+        return self::getSourcePlaylistData($records, $relation, $sourceKey);
+    }
+
+    public static function map(
+        Collection $records,
+        array $data,
+        string $relation,
+        string $sourceKey,
+        string $modelClass,
+        ?array $sourcePlaylistData = null
+    ) {
+        return self::mapRecordsToSourcePlaylist(
+            $records,
+            $data,
+            $relation,
+            $sourceKey,
+            $modelClass,
+            $sourcePlaylistData
+        );
+    }
+
+    public static function options(
+        ?int $customPlaylistId,
+        array $group,
+        string $relation,
+        string $sourceKey
+    ) {
+        return self::availablePlaylistsForGroup(
+            $customPlaylistId,
+            $group,
+            $relation,
+            $sourceKey
+        );
+    }
+}
+
+it('consolidates all child playlists for a parent and source', function () {
+    $user = User::factory()->create();
+    auth()->setUser($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $childA = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $childB = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $groupParent = Group::factory()->for($user)->for($parent)->createQuietly();
+    $groupA = Group::factory()->for($user)->for($childA)->createQuietly();
+    $groupB = Group::factory()->for($user)->for($childB)->createQuietly();
+
+    $source = 'src-1';
+
+    TestChannel::create([
+        'name' => 'p',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $parent->id,
+        'group_id' => $groupParent->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name' => 'a',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $childA->id,
+        'group_id' => $groupA->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name' => 'b',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $childB->id,
+        'group_id' => $groupB->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $records = TestChannel::where('playlist_id', $parent->id)->get();
+
+    [$groups, $needs] = HandlesSourcePlaylistTestClass::data($records, 'channels', 'source_id');
+
+    expect($needs)->toBeTrue();
+    expect($groups)->toHaveCount(1);
+
+    $group = $groups->first();
+    expect($group['playlists']->keys()->sort()->values()->all())->toEqualCanonicalizing([
+        $parent->id,
+        $childA->id,
+        $childB->id,
+    ]);
+});
+
+it('throws when conflicting playlist selections are provided for the same source', function () {
+    $user = User::factory()->create();
+    auth()->setUser($user);
+
+    $parent1 = Playlist::factory()->for($user)->create();
+    $child1 = Playlist::factory()->for($user)->create(['parent_id' => $parent1->id]);
+    $parent2 = Playlist::factory()->for($user)->create();
+    $child2 = Playlist::factory()->for($user)->create(['parent_id' => $parent2->id]);
+
+    $gP1 = Group::factory()->for($user)->for($parent1)->createQuietly();
+    $gC1 = Group::factory()->for($user)->for($child1)->createQuietly();
+    $gP2 = Group::factory()->for($user)->for($parent2)->createQuietly();
+    $gC2 = Group::factory()->for($user)->for($child2)->createQuietly();
+
+    $source = 'src-1';
+
+    TestChannel::create([
+        'name' => 'p1',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $parent1->id,
+        'group_id' => $gP1->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name' => 'c1',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $child1->id,
+        'group_id' => $gC1->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name' => 'p2',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $parent2->id,
+        'group_id' => $gP2->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name' => 'c2',
+        'enabled' => true,
+        'shift' => 0,
+        'user_id' => $user->id,
+        'playlist_id' => $child2->id,
+        'group_id' => $gC2->id,
+        'source_id' => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $records = TestChannel::where('playlist_id', $parent1->id)->get();
+    $sourcePlaylistData = HandlesSourcePlaylistTestClass::data($records, 'channels', 'source_id');
+    [$groups] = $sourcePlaylistData;
+
+    $groupKeys = [];
+    foreach ($groups as $key => $grp) {
+        $groupKeys[$grp['parent_id']] = $key;
+    }
+
+    $data = [
+        'source_playlists' => [
+            $groupKeys[$parent1->id] => $child1->id,
+            $groupKeys[$parent2->id] => $child2->id,
+        ],
+    ];
+
+    expect(fn () => HandlesSourcePlaylistTestClass::map(
+        $records,
+        $data,
+        'channels',
+        'source_id',
+        TestChannel::class,
+        $sourcePlaylistData
+    ))->toThrow(ValidationException::class);
+});
+
+it('filters playlists already used in the custom playlist', function () {
+    $user = User::factory()->create();
+    auth()->setUser($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+
+    $gParent = Group::factory()->for($user)->for($parent)->createQuietly();
+    $gChild  = Group::factory()->for($user)->for($child)->createQuietly();
+
+    $source = 'src-1';
+
+    $parentChannel = TestChannel::create([
+        'name'       => 'p',
+        'enabled'    => true,
+        'shift'      => 0,
+        'user_id'    => $user->id,
+        'playlist_id'=> $parent->id,
+        'group_id'   => $gParent->id,
+        'source_id'  => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name'       => 'c',
+        'enabled'    => true,
+        'shift'      => 0,
+        'user_id'    => $user->id,
+        'playlist_id'=> $child->id,
+        'group_id'   => $gChild->id,
+        'source_id'  => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $records = TestChannel::where('playlist_id', $parent->id)->get();
+    [$groups] = HandlesSourcePlaylistTestClass::data($records, 'channels', 'source_id');
+    $group = $groups->first();
+
+    $custom = CustomPlaylist::factory()->for($user)->create();
+    $custom->channels()->attach($parentChannel->id);
+
+    $options = HandlesSourcePlaylistTestClass::options($custom->id, $group, 'channels', 'source_id');
+
+    expect($options->keys()->all())->toEqual([$child->id]);
+});
+
+it('throws when a playlist outside the group is selected at the group level', function () {
+    $user = User::factory()->create();
+    auth()->setUser($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $other  = Playlist::factory()->for($user)->create();
+
+    $gParent = Group::factory()->for($user)->for($parent)->createQuietly();
+    $gChild  = Group::factory()->for($user)->for($child)->createQuietly();
+
+    $source = 'src-1';
+
+    TestChannel::create([
+        'name'       => 'p',
+        'enabled'    => true,
+        'shift'      => 0,
+        'user_id'    => $user->id,
+        'playlist_id'=> $parent->id,
+        'group_id'   => $gParent->id,
+        'source_id'  => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name'       => 'c',
+        'enabled'    => true,
+        'shift'      => 0,
+        'user_id'    => $user->id,
+        'playlist_id'=> $child->id,
+        'group_id'   => $gChild->id,
+        'source_id'  => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $records = TestChannel::where('playlist_id', $parent->id)->get();
+    $sourcePlaylistData = HandlesSourcePlaylistTestClass::data($records, 'channels', 'source_id');
+    [$groups] = $sourcePlaylistData;
+    $groupKey = $groups->keys()->first();
+
+    $data = [
+        'source_playlists' => [
+            $groupKey => $other->id,
+        ],
+    ];
+
+    expect(fn () => HandlesSourcePlaylistTestClass::map(
+        $records,
+        $data,
+        'channels',
+        'source_id',
+        TestChannel::class,
+        $sourcePlaylistData
+    ))->toThrow(ValidationException::class);
+});
+
+it('throws when a playlist outside the group is selected for an item', function () {
+    $user = User::factory()->create();
+    auth()->setUser($user);
+
+    $parent = Playlist::factory()->for($user)->create();
+    $child  = Playlist::factory()->for($user)->create(['parent_id' => $parent->id]);
+    $other  = Playlist::factory()->for($user)->create();
+
+    $gParent = Group::factory()->for($user)->for($parent)->createQuietly();
+    $gChild  = Group::factory()->for($user)->for($child)->createQuietly();
+
+    $source = 'src-1';
+
+    TestChannel::create([
+        'name'       => 'p',
+        'enabled'    => true,
+        'shift'      => 0,
+        'user_id'    => $user->id,
+        'playlist_id'=> $parent->id,
+        'group_id'   => $gParent->id,
+        'source_id'  => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    TestChannel::create([
+        'name'       => 'c',
+        'enabled'    => true,
+        'shift'      => 0,
+        'user_id'    => $user->id,
+        'playlist_id'=> $child->id,
+        'group_id'   => $gChild->id,
+        'source_id'  => $source,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $records = TestChannel::where('playlist_id', $parent->id)->get();
+    $sourcePlaylistData = HandlesSourcePlaylistTestClass::data($records, 'channels', 'source_id');
+    [$groups] = $sourcePlaylistData;
+    $groupKey = $groups->keys()->first();
+
+    $data = [
+        'source_playlist_items' => [
+            $groupKey => [
+                $source => $other->id,
+            ],
+        ],
+    ];
+
+    expect(fn () => HandlesSourcePlaylistTestClass::map(
+        $records,
+        $data,
+        'channels',
+        'source_id',
+        TestChannel::class,
+        $sourcePlaylistData
+    ))->toThrow(ValidationException::class);
+});
+


### PR DESCRIPTION
## Summary
- consolidate duplicate groups so a parent item with several children is handled together
- validate conflicting playlist selections when the same source is mapped multiple times
- add coverage for items shared across a parent and multiple child playlists
- filter out source playlists already used in the selected custom playlist and recompute options when the target playlist changes
- validate source playlist IDs against available options and reject unauthorized selections
- reset source playlist selections when the target custom playlist changes

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68c103ea4e9083218c5393046c23e4c5