### PR TITLE
Show parent playlists when editing custom playlists

### DIFF
--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\CustomPlaylistResource\RelationManagers;
 
 use App\Filament\Resources\ChannelResource;
+use App\Filament\Concerns\DisplaysPlaylistMembership;
 use App\Models\Channel;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -21,6 +22,7 @@ use Spatie\Tags\Tag;
 
 class ChannelsRelationManager extends RelationManager
 {
+    use DisplaysPlaylistMembership;
     protected static string $relationship = 'channels';
 
     protected static ?string $label = 'Live Channels';
@@ -112,8 +114,13 @@ class ChannelsRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
-        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.name')
             ->label('Parent Playlist')
+            ->formatStateUsing(function ($state, Channel $record) {
+                $display = self::playlistDisplay($record, 'source_id');
+                return $display !== '' ? $display : ($record->playlist?->name ?? $state);
+            })
+            ->tooltip(fn (Channel $record) => self::playlistTooltip($record, 'source_id'))
             ->toggleable()
             ->sortable();
 
@@ -125,7 +132,7 @@ class ChannelsRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist.parent'])
+                $query->with(['tags', 'epgChannel', 'playlist'])
                     ->withCount(['failovers'])
                     ->where('is_vod', false); // Only show live channels
             })


### PR DESCRIPTION
## Summary
- Display originating parent playlist for channels, VOD items and series in custom playlists
- Enable switching source playlist by showing current membership and tooltip hints

## Testing
- `./vendor/bin/pest` *(fails: database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c199d061c88321960d35ad4ab8b5b6