### PR TITLE
Skip empty source playlist groups

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -4,15 +4,15 @@ namespace App\Filament\BulkActions;
 
 use App\Models\CustomPlaylist;
 use App\Models\Playlist;
-use Illuminate\Support\Facades\DB;
 use Filament\Forms;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Set;
 use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tables;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -47,24 +47,24 @@ trait HandlesSourcePlaylist
     /**
      * Build duplicate playlist metadata for the given records.
      *
-     * @param Collection $records   Selected records from the bulk action.
-     * @param string     $relation  Relationship name used to query playlist items (channels, series, etc.).
-     * @param string     $sourceKey Source identifier column on the related model.
+     * @param  Collection  $records  Selected records from the bulk action.
+     * @param  string  $relation  Relationship name used to query playlist items (channels, series, etc.).
+     * @param  string  $sourceKey  Source identifier column on the related model.
      * @return array{0: Collection, 1: bool, 2: Collection, 3: Collection} Tuple containing
-     *                                             duplicate groups, whether a source playlist is
-     *                                             needed, the source IDs of the records, and a
-     *                                             map of composite playlist/source keys to their
-     *                                             parent-child group key.
-    */
+     *                                                                     duplicate groups, whether a source playlist is
+     *                                                                     needed, the source IDs of the records, and a
+     *                                                                     map of composite playlist/source keys to their
+     *                                                                     parent-child group key.
+     */
     protected static function getSourcePlaylistData(Collection $records, string $relation, string $sourceKey): array
     {
         $recordSourceIds = $records->pluck($sourceKey)->unique();
 
         $rows = DB::table($relation)
-            ->join('playlists', $relation . '.playlist_id', '=', 'playlists.id')
+            ->join('playlists', $relation.'.playlist_id', '=', 'playlists.id')
             ->where('playlists.user_id', auth()->id())
             ->whereIn($sourceKey, $recordSourceIds)
-            ->select('playlist_id', 'parent_id', $sourceKey . ' as source_id')
+            ->select('playlist_id', 'parent_id', $sourceKey.' as source_id')
             ->get();
 
         $playlistIds = $rows->pluck('playlist_id')
@@ -100,20 +100,20 @@ trait HandlesSourcePlaylist
                     }
 
                     $childKey = $childIds->sort()->join('-');
-                    $groupKey = $parentId . '-' . $childKey;
+                    $groupKey = $parentId.'-'.$childKey;
 
                     $groups[$groupKey] ??= [
-                        'parent_id'      => $parentId,
-                        'child_ids'      => $childIds->values()->all(),
-                        'playlists'      => collect($playlistNames->only(array_merge([$parentId], $childIds->all()))),
-                        'source_ids'     => [],
+                        'parent_id' => $parentId,
+                        'child_ids' => $childIds->values()->all(),
+                        'playlists' => collect($playlistNames->only(array_merge([$parentId], $childIds->all()))),
+                        'source_ids' => [],
                         'composite_keys' => [],
                     ];
 
                     $groups[$groupKey]['source_ids'][] = $sourceId;
 
                     foreach (array_merge([$parentId], $childIds->all()) as $id) {
-                        $groups[$groupKey]['composite_keys'][] = $id . ':' . $sourceId;
+                        $groups[$groupKey]['composite_keys'][] = $id.':'.$sourceId;
                     }
                 });
             });
@@ -162,14 +162,14 @@ trait HandlesSourcePlaylist
      * duplicate parent/child groups and optionally override individual
      * records within those groups.
      *
-     * @param Collection      $records            Records selected in the bulk action.
-     * @param string          $relation           Relationship name used to fetch playlist items.
-     * @param string          $sourceKey          Column containing the source ID on the related model.
-     * @param string          $itemLabel          Human-readable label for the record type (channel, series, etc.).
-     * @param string          $modelClass         Fully qualified model class for querying record details.
-     * @param array|null      $sourcePlaylistData Cached metadata returned from {@see getSourcePlaylistData}.
-     *                                           Passed by reference so callers can reuse the computed data.
-     * @return array                             Array of Filament form components for inclusion in the bulk action.
+     * @param  Collection  $records  Records selected in the bulk action.
+     * @param  string  $relation  Relationship name used to fetch playlist items.
+     * @param  string  $sourceKey  Column containing the source ID on the related model.
+     * @param  string  $itemLabel  Human-readable label for the record type (channel, series, etc.).
+     * @param  string  $modelClass  Fully qualified model class for querying record details.
+     * @param  array|null  $sourcePlaylistData  Cached metadata returned from {@see getSourcePlaylistData}.
+     *                                          Passed by reference so callers can reuse the computed data.
+     * @return array Array of Filament form components for inclusion in the bulk action.
      */
     protected static function buildSourcePlaylistForm(
         Collection $records,
@@ -194,49 +194,60 @@ trait HandlesSourcePlaylist
         foreach ($duplicateGroups as $groupKey => $group) {
             $parentName = $group['playlists'][$group['parent_id']];
             $childNames = $group['playlists']->except($group['parent_id'])->values()->implode(', ');
-            $label      = $childNames ? "{$parentName} / {$childNames}" : $parentName;
+            $label = $childNames ? "{$parentName} / {$childNames}" : $parentName;
 
             $fields[] = Forms\Components\Fieldset::make($label)
-                ->schema([
-                    Forms\Components\Select::make("source_playlists.{$groupKey}")
-                        ->label('Which playlist do you want to add from?')
-                        ->options(fn (Get $get) => self::availablePlaylistsForGroup(
-                            $get('playlist'),
-                            $group,
-                            $relation,
-                            $sourceKey
-                        )->toArray())
-                        ->placeholder('Choose playlist')
-                        ->searchable()
-                        ->live()
-                        ->reactive(),
-                    Actions::make([
-                        Action::make("items_{$groupKey}")
-                            ->label('View Affected Items')
-                            ->form(function (Get $get) use ($group, $groupKey, $relation, $sourceKey) {
-                                $existing = $get("source_playlist_items.{$groupKey}") ?? [];
-                                $default  = $get("source_playlists.{$groupKey}");
+                ->visible(fn (Get $get) => self::availablePlaylistsForGroup(
+                    $get('playlist'),
+                    $group,
+                    $relation,
+                    $sourceKey
+                )->isNotEmpty())
+                ->schema(function (Get $get) use ($group, $groupKey, $relation, $sourceKey) {
+                    $available = self::availablePlaylistsForGroup(
+                        $get('playlist'),
+                        $group,
+                        $relation,
+                        $sourceKey
+                    );
 
-                                return collect($group['source_ids'])->map(function ($sourceId) use ($group, $existing, $default, $relation, $sourceKey) {
-                                    return Forms\Components\Select::make("items.{$sourceId}")
-                                        ->label((string) $sourceId)
-                                        ->options(fn (Get $get) => self::availablePlaylistsForGroup(
-                                            $get('playlist'),
-                                            $group,
-                                            $relation,
-                                            $sourceKey
-                                        )->toArray())
-                                        ->placeholder('Choose playlist')
-                                        ->default($existing[$sourceId] ?? $default)
-                                        ->searchable()
-                                        ->reactive();
-                                })->toArray();
-                            })
-                            ->action(function (array $formData, Set $set) use ($groupKey) {
-                                $set("source_playlist_items.{$groupKey}", $formData['items'] ?? []);
-                            }),
-                    ])->columnSpanFull(),
-                ]);
+                    if ($available->isEmpty()) {
+                        return [];
+                    }
+
+                    $options = $available->toArray();
+
+                    return [
+                        Forms\Components\Select::make("source_playlists.{$groupKey}")
+                            ->label('Which playlist do you want to add from?')
+                            ->options($options)
+                            ->placeholder('Choose playlist')
+                            ->searchable()
+                            ->live()
+                            ->reactive(),
+                        Actions::make([
+                            Action::make("items_{$groupKey}")
+                                ->label('View Affected Items')
+                                ->form(function (Get $get) use ($group, $groupKey, $options) {
+                                    $existing = $get("source_playlist_items.{$groupKey}") ?? [];
+                                    $default = $get("source_playlists.{$groupKey}");
+
+                                    return collect($group['source_ids'])->map(function ($sourceId) use ($existing, $default, $options) {
+                                        return Forms\Components\Select::make("items.{$sourceId}")
+                                            ->label((string) $sourceId)
+                                            ->options($options)
+                                            ->placeholder('Choose playlist')
+                                            ->default($existing[$sourceId] ?? $default)
+                                            ->searchable()
+                                            ->reactive();
+                                    })->toArray();
+                                })
+                                ->action(function (array $formData, Set $set) use ($groupKey) {
+                                    $set("source_playlist_items.{$groupKey}", $formData['items'] ?? []);
+                                }),
+                        ])->columnSpanFull(),
+                    ];
+                });
         }
 
         return $fields;
@@ -250,15 +261,16 @@ trait HandlesSourcePlaylist
      * source playlist chosen, and replaces records with their counterpart from
      * the selected source playlist.
      *
-     * @param Collection $records           Records originally selected in the bulk action.
-     * @param array      $data              Form data submitted by the user.
-     * @param string     $relation          Relationship name used to fetch playlist items.
-     * @param string     $sourceKey         Source identifier column on the related model.
-     * @param string     $modelClass        Fully qualified model class name for the records.
-     * @param array|null $sourcePlaylistData Cached metadata from {@see getSourcePlaylistData}.
-     *                                       Passed by reference to avoid recomputation.
-     * @return Collection                    Collection of records mapped to their chosen source playlist.
-     * @throws ValidationException           If any duplicate group lacks a source selection.
+     * @param  Collection  $records  Records originally selected in the bulk action.
+     * @param  array  $data  Form data submitted by the user.
+     * @param  string  $relation  Relationship name used to fetch playlist items.
+     * @param  string  $sourceKey  Source identifier column on the related model.
+     * @param  string  $modelClass  Fully qualified model class name for the records.
+     * @param  array|null  $sourcePlaylistData  Cached metadata from {@see getSourcePlaylistData}.
+     *                                          Passed by reference to avoid recomputation.
+     * @return Collection Collection of records mapped to their chosen source playlist.
+     *
+     * @throws ValidationException If any duplicate group lacks a source selection.
      */
     protected static function mapRecordsToSourcePlaylist(
         Collection $records,
@@ -276,22 +288,33 @@ trait HandlesSourcePlaylist
 
         if ($needsSourcePlaylist) {
             $groupSelections = collect($data['source_playlists'] ?? []);
-            $itemSelections  = collect($data['source_playlist_items'] ?? []);
+            $itemSelections = collect($data['source_playlist_items'] ?? []);
 
             $sourceAssignments = collect();
 
             foreach ($duplicateGroups as $groupKey => $group) {
-                $groupChoice = $groupSelections->get($groupKey);
-                $items       = collect($itemSelections->get($groupKey) ?? []);
+                $available = self::availablePlaylistsForGroup(
+                    $data['playlist'] ?? null,
+                    $group,
+                    $relation,
+                    $sourceKey
+                );
 
-                if ($groupChoice && ! $group['playlists']->has($groupChoice)) {
+                if ($available->isEmpty()) {
+                    continue;
+                }
+
+                $groupChoice = $groupSelections->get($groupKey);
+                $items = collect($itemSelections->get($groupKey) ?? []);
+
+                if ($groupChoice && ! $available->has($groupChoice)) {
                     throw ValidationException::withMessages([
                         'source_playlists' => 'Invalid playlist selection.',
                     ]);
                 }
 
                 foreach ($items as $playlistId) {
-                    if ($playlistId && ! $group['playlists']->has($playlistId)) {
+                    if ($playlistId && ! $available->has($playlistId)) {
                         throw ValidationException::withMessages([
                             'source_playlists' => 'Invalid playlist selection.',
                         ]);
@@ -336,8 +359,8 @@ trait HandlesSourcePlaylist
                 ->map->keyBy($sourceKey);
 
             $records = $records->map(function ($record) use ($sourceAssignments, $sourceMaps, $sourceToGroup, $sourceKey) {
-                $sourceId  = $record->$sourceKey;
-                $composite = $record->playlist_id . ':' . $sourceId;
+                $sourceId = $record->$sourceKey;
+                $composite = $record->playlist_id.':'.$sourceId;
 
                 if (! $sourceToGroup->has($composite)) {
                     return $record;
@@ -358,12 +381,12 @@ trait HandlesSourcePlaylist
      * Construct a Filament bulk action that adds the selected records to a
      * custom playlist, including optional source playlist disambiguation.
      *
-     * @param string $modelClass    Fully qualified model class for the records.
-     * @param string $relation      Relationship name used by the custom playlist (channels, series, vods).
-     * @param string $sourceKey     Column containing the source ID on the related model.
-     * @param string $itemLabel     Human-readable label for the record type.
-     * @param string $tagType       Tag type used when assigning categories/groups.
-     * @param string $categoryLabel Label displayed for the category select.
+     * @param  string  $modelClass  Fully qualified model class for the records.
+     * @param  string  $relation  Relationship name used by the custom playlist (channels, series, vods).
+     * @param  string  $sourceKey  Column containing the source ID on the related model.
+     * @param  string  $itemLabel  Human-readable label for the record type.
+     * @param  string  $tagType  Tag type used when assigning categories/groups.
+     * @param  string  $categoryLabel  Label displayed for the category select.
      * @return Tables\Actions\BulkAction Configured bulk action ready to attach to a Filament table.
      */
     protected static function buildAddToCustomPlaylistAction(
@@ -410,12 +433,13 @@ trait HandlesSourcePlaylist
                         ->disabled(fn (Get $get) => ! $get('playlist'))
                         ->helperText(fn (Get $get) => ! $get('playlist')
                             ? 'Select a custom playlist first.'
-                            : 'Select the ' . ($categoryLabel === 'Custom Group' ? 'group' : 'category') .
-                                ' you would like to assign to the selected ' . $itemLabel . ' to.')
+                            : 'Select the '.($categoryLabel === 'Custom Group' ? 'group' : 'category').
+                                ' you would like to assign to the selected '.$itemLabel.' to.')
                         ->options(function ($get) use ($tagType) {
                             $customList = CustomPlaylist::find($get('playlist'));
+
                             return $customList ? $customList->tags()
-                                ->where('type', $customList->uuid . $tagType)
+                                ->where('type', $customList->uuid.$tagType)
                                 ->get()
                                 ->mapWithKeys(fn ($tag) => [$tag->getAttributeValue('name') => $tag->getAttributeValue('name')])
                                 ->toArray() : [];
@@ -461,7 +485,7 @@ trait HandlesSourcePlaylist
             ->after(function () use ($itemLabel) {
                 FilamentNotification::make()
                     ->success()
-                    ->title(ucfirst($itemLabel) . ' added to custom playlist')
+                    ->title(ucfirst($itemLabel).' added to custom playlist')
                     ->body("The selected {$itemLabel} have been added to the chosen custom playlist.")
                     ->send();
             })


### PR DESCRIPTION
## Summary
- compute available playlists upfront and hide fieldsets with no options
- ignore duplicate groups with no available source playlists during mapping

## Testing
- `./vendor/bin/pest` *(fails: Database file at path [/workspace/m3u-editor/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c19db0b8c8832183c5789f4a3e6a0c