### PR TITLE
Show parent playlists when editing custom playlists

### DIFF
--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\CustomPlaylistResource\RelationManagers;
 
 use App\Filament\Resources\ChannelResource;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Models\Channel;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -11,6 +12,7 @@ use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Columns\SpatieTagsColumn;
+use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -21,6 +23,7 @@ use Spatie\Tags\Tag;
 
 class ChannelsRelationManager extends RelationManager
 {
+    use HandlesSourcePlaylist;
     protected static string $relationship = 'channels';
 
     protected static ?string $label = 'Live Channels';
@@ -112,8 +115,14 @@ class ChannelsRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
-        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+        $defaultColumns[] = SelectColumn::make('playlist_id')
             ->label('Parent Playlist')
+            ->getStateUsing(fn (Channel $record) => $record->playlist_id)
+            ->options(fn (Channel $record) => $this->playlistOptions($record))
+            ->disabled(fn (Channel $record) => count($this->playlistOptions($record)) <= 1)
+            ->selectablePlaceholder(false)
+            ->updateStateUsing(fn ($state) => $state)
+            ->afterStateUpdated(fn ($state, Channel $record) => $this->changeSourcePlaylist($record, (int) $state))
             ->toggleable()
             ->sortable();
 
@@ -125,7 +134,7 @@ class ChannelsRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist.parent'])
+                $query->with(['tags', 'epgChannel', 'playlist'])
                     ->withCount(['failovers'])
                     ->where('is_vod', false); // Only show live channels
             })
@@ -257,7 +266,51 @@ class ChannelsRelationManager extends RelationManager
                     ->icon('heroicon-o-squares-plus')
                     ->modalIcon('heroicon-o-squares-plus')
                     ->modalDescription('Add to group')
-                    ->modalSubmitActionLabel('Yes, add to group'),
+            ->modalSubmitActionLabel('Yes, add to group'),
             ]);
+    }
+
+    protected function playlistOptions(Channel $record): array
+    {
+        [$groups] = self::getSourcePlaylistData(collect([$record]), 'channels', 'source_id');
+
+        if ($groups->isEmpty()) {
+            return [$record->playlist_id => $record->playlist?->name];
+        }
+
+        $group = $groups->first();
+        $options = self::availablePlaylistsForGroup($this->ownerRecord->id, $group, 'channels', 'source_id');
+
+        return $options->put($record->playlist_id, $record->playlist?->name)->toArray();
+    }
+
+    protected function changeSourcePlaylist(Channel $record, int $playlistId): void
+    {
+        if ($playlistId === $record->playlist_id) {
+            return;
+        }
+
+        $replacement = Channel::where('playlist_id', $playlistId)
+            ->where('source_id', $record->source_id)
+            ->first();
+
+        if (! $replacement) {
+            FilamentNotification::make()
+                ->title('Channel not found in selected playlist')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $this->ownerRecord->channels()->detach($record->id);
+        $this->ownerRecord->channels()->attach($replacement->id);
+
+        FilamentNotification::make()
+            ->title('Parent playlist updated')
+            ->success()
+            ->send();
+
+        $this->dispatch('refresh');
     }
 }

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/SeriesRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\CustomPlaylistResource\RelationManagers;
 
 use App\Filament\Resources\SeriesResource;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Models\Series;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -11,6 +12,7 @@ use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Columns\SpatieTagsColumn;
+use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -20,6 +22,7 @@ use Spatie\Tags\Tag;
 
 class SeriesRelationManager extends RelationManager
 {
+    use HandlesSourcePlaylist;
     protected static string $relationship = 'series';
 
     public function isReadOnly(): bool
@@ -103,8 +106,14 @@ class SeriesRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 6, 0, [$groupColumn]);
 
-        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+        $defaultColumns[] = SelectColumn::make('playlist_id')
             ->label('Parent Playlist')
+            ->getStateUsing(fn (Series $record) => $record->playlist_id)
+            ->options(fn (Series $record) => $this->playlistOptions($record))
+            ->disabled(fn (Series $record) => count($this->playlistOptions($record)) <= 1)
+            ->selectablePlaceholder(false)
+            ->updateStateUsing(fn ($state) => $state)
+            ->afterStateUpdated(fn ($state, Series $record) => $this->changeSourcePlaylist($record, (int) $state))
             ->toggleable()
             ->sortable();
 
@@ -115,7 +124,7 @@ class SeriesRelationManager extends RelationManager
             ->filtersTriggerAction(function ($action) {
                 return $action->button()->label('Filters');
             })
-            ->modifyQueryUsing(fn (Builder $query) => $query->with('playlist.parent'))
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('playlist'))
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
             ->columns($defaultColumns)
@@ -230,7 +239,51 @@ class SeriesRelationManager extends RelationManager
                     ->icon('heroicon-o-squares-plus')
                     ->modalIcon('heroicon-o-squares-plus')
                     ->modalDescription('Add to category')
-                    ->modalSubmitActionLabel('Yes, add to category'),
+            ->modalSubmitActionLabel('Yes, add to category'),
             ]);
+    }
+
+    protected function playlistOptions(Series $record): array
+    {
+        [$groups] = self::getSourcePlaylistData(collect([$record]), 'series', 'source_series_id');
+
+        if ($groups->isEmpty()) {
+            return [$record->playlist_id => $record->playlist?->name];
+        }
+
+        $group = $groups->first();
+        $options = self::availablePlaylistsForGroup($this->ownerRecord->id, $group, 'series', 'source_series_id');
+
+        return $options->put($record->playlist_id, $record->playlist?->name)->toArray();
+    }
+
+    protected function changeSourcePlaylist(Series $record, int $playlistId): void
+    {
+        if ($playlistId === $record->playlist_id) {
+            return;
+        }
+
+        $replacement = Series::where('playlist_id', $playlistId)
+            ->where('source_series_id', $record->source_series_id)
+            ->first();
+
+        if (! $replacement) {
+            FilamentNotification::make()
+                ->title('Series not found in selected playlist')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $this->ownerRecord->series()->detach($record->id);
+        $this->ownerRecord->series()->attach($replacement->id);
+
+        FilamentNotification::make()
+            ->title('Parent playlist updated')
+            ->success()
+            ->send();
+
+        $this->dispatch('refresh');
     }
 }

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/VodRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\CustomPlaylistResource\RelationManagers;
 
 use App\Filament\Resources\VodResource;
+use App\Filament\BulkActions\HandlesSourcePlaylist;
 use App\Models\Channel;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -11,6 +12,7 @@ use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Columns\SpatieTagsColumn;
+use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -21,6 +23,7 @@ use Spatie\Tags\Tag;
 
 class VodRelationManager extends RelationManager
 {
+    use HandlesSourcePlaylist;
     protected static string $relationship = 'channels';
 
     protected static ?string $label = 'VOD Channels';
@@ -112,8 +115,14 @@ class VodRelationManager extends RelationManager
         // Inject the custom group column after the group column
         array_splice($defaultColumns, 13, 0, [$groupColumn]);
 
-        $defaultColumns[] = Tables\Columns\TextColumn::make('playlist.parent.name')
+        $defaultColumns[] = SelectColumn::make('playlist_id')
             ->label('Parent Playlist')
+            ->getStateUsing(fn (Channel $record) => $record->playlist_id)
+            ->options(fn (Channel $record) => $this->playlistOptions($record))
+            ->disabled(fn (Channel $record) => count($this->playlistOptions($record)) <= 1)
+            ->selectablePlaceholder(false)
+            ->updateStateUsing(fn ($state) => $state)
+            ->afterStateUpdated(fn ($state, Channel $record) => $this->changeSourcePlaylist($record, (int) $state))
             ->toggleable()
             ->sortable();
 
@@ -125,7 +134,7 @@ class VodRelationManager extends RelationManager
                 return $action->button()->label('Filters');
             })
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['tags', 'epgChannel', 'playlist.parent'])
+                $query->with(['tags', 'epgChannel', 'playlist'])
                     ->withCount(['failovers'])
                     ->where('is_vod', true); // Only show VOD content
             })
@@ -249,7 +258,51 @@ class VodRelationManager extends RelationManager
                     ->icon('heroicon-o-squares-plus')
                     ->modalIcon('heroicon-o-squares-plus')
                     ->modalDescription('Add to group')
-                    ->modalSubmitActionLabel('Yes, add to group'),
+            ->modalSubmitActionLabel('Yes, add to group'),
             ]);
+    }
+
+    protected function playlistOptions(Channel $record): array
+    {
+        [$groups] = self::getSourcePlaylistData(collect([$record]), 'channels', 'source_id');
+
+        if ($groups->isEmpty()) {
+            return [$record->playlist_id => $record->playlist?->name];
+        }
+
+        $group = $groups->first();
+        $options = self::availablePlaylistsForGroup($this->ownerRecord->id, $group, 'channels', 'source_id');
+
+        return $options->put($record->playlist_id, $record->playlist?->name)->toArray();
+    }
+
+    protected function changeSourcePlaylist(Channel $record, int $playlistId): void
+    {
+        if ($playlistId === $record->playlist_id) {
+            return;
+        }
+
+        $replacement = Channel::where('playlist_id', $playlistId)
+            ->where('source_id', $record->source_id)
+            ->first();
+
+        if (! $replacement) {
+            FilamentNotification::make()
+                ->title('Channel not found in selected playlist')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $this->ownerRecord->channels()->detach($record->id);
+        $this->ownerRecord->channels()->attach($replacement->id);
+
+        FilamentNotification::make()
+            ->title('Parent playlist updated')
+            ->success()
+            ->send();
+
+        $this->dispatch('refresh');
     }
 }


### PR DESCRIPTION
## Summary
- Display originating parent playlist for channels, VOD items and series in custom playlists with an inline select
- Allow switching the source playlist by finding alternate records and swapping the custom playlist pivot
- Keep the source playlist selector label on one line and render "View Affected Items" inline with the dropdown
- Require choosing a source playlist and disable "View Affected Items" until a playlist is selected
- Persist item-level overrides from "View Affected Items" so adding to playlists honours per-item source selections
- Style the "View Affected Items" suffix action with an eye icon and primary button colour
- Populate parent playlist columns and show item names in "View Affected Items"

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: Database file at path [/workspace/m3u-editor/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c199d061c88321960d35ad4ab8b5b6