### PR TITLE
Display item selector inline

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -237,18 +237,23 @@ trait HandlesSourcePlaylist
                                     $default  = $get("source_playlists.{$groupKey}");
 
                                     return collect($group['source_ids'])->map(function ($sourceId) use ($group, $existing, $default, $relation, $sourceKey, $labels) {
-                                        return Forms\Components\Select::make("items.{$sourceId}")
-                                            ->label($labels[$sourceId] ?? (string) $sourceId)
-                                            ->options(fn (Get $get) => self::availablePlaylistsForGroup(
-                                                $get('playlist'),
-                                                $group,
-                                                $relation,
-                                                $sourceKey
-                                            )->toArray())
-                                            ->placeholder('Choose playlist')
-                                            ->default($existing[$sourceId] ?? $default)
-                                            ->searchable()
-                                            ->reactive();
+                                        return Forms\Components\Grid::make(2)
+                                            ->schema([
+                                                Forms\Components\Select::make("items.{$sourceId}")
+                                                    ->label($labels[$sourceId] ?? (string) $sourceId)
+                                                    ->options(fn (Get $get) => self::availablePlaylistsForGroup(
+                                                        $get('playlist'),
+                                                        $group,
+                                                        $relation,
+                                                        $sourceKey
+                                                    )->toArray())
+                                                    ->placeholder('Choose playlist')
+                                                    ->default($existing[$sourceId] ?? $default)
+                                                    ->searchable()
+                                                    ->reactive()
+                                                    ->inlineLabel()
+                                                    ->columnSpan(1),
+                                            ]);
                                     })->toArray();
                                 })
                                 ->action(function (array $formData, Set $set) use ($groupKey) {


### PR DESCRIPTION
## Summary
- show selector inline with channel title in affected items modal

## Testing
- `php artisan test` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dd9ede4883219027aec5f104d840