### PR TITLE
Display item selector inline

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -234,25 +234,30 @@ trait HandlesSourcePlaylist
                                 ->extraAttributes(['class' => 'whitespace-nowrap'])
                                 ->form(function (Get $get) use ($group, $groupKey, $relation, $sourceKey, $labels) {
                                     $existing = $get("source_playlist_items.{$groupKey}") ?? [];
-                                    $default  = $get("source_playlists.{$groupKey}");
+                                    $default = $get("source_playlists.{$groupKey}");
 
                                     return collect($group['source_ids'])->map(function ($sourceId) use ($group, $existing, $default, $relation, $sourceKey, $labels) {
-                                        return Forms\Components\Select::make("items.{$sourceId}")
-                                            ->label($labels[$sourceId] ?? (string) $sourceId)
-                                            ->options(fn (Get $get) => self::availablePlaylistsForGroup(
-                                                $get('playlist'),
-                                                $group,
-                                                $relation,
-                                                $sourceKey
-                                            )->toArray())
-                                            ->placeholder('Choose playlist')
-                                            ->default($existing[$sourceId] ?? $default)
-                                            ->searchable()
-                                            ->reactive();
+                                        return Forms\Components\Grid::make(2)
+                                            ->schema([
+                                                Forms\Components\Select::make("items.{$sourceId}")
+                                                    ->label($labels[$sourceId] ?? (string) $sourceId)
+                                                    ->options(fn (Get $get) => self::availablePlaylistsForGroup(
+                                                        $get('playlist'),
+                                                        $group,
+                                                        $relation,
+                                                        $sourceKey
+                                                    )->toArray())
+                                                    ->placeholder('Choose playlist')
+                                                    ->default($existing[$sourceId] ?? $default)
+                                                    ->searchable()
+                                                    ->reactive()
+                                                    ->inlineLabel()
+                                                    ->columnSpan(1),
+                                            ]);
                                     })->toArray();
                                 })
-                                ->action(function (array $formData, Set $set) use ($groupKey) {
-                                    $set("source_playlist_items.{$groupKey}", $formData['items'] ?? []);
+                                ->action(function (array $data, Set $set) use ($groupKey) {
+                                    $set("source_playlist_items.{$groupKey}", $data['items'] ?? []);
                                 })
                                 ->disabled(fn (Get $get) => blank($get("source_playlists.{$groupKey}")))
                         ),


### PR DESCRIPTION
## Summary
- show selector inline with channel title in affected items modal
- resolve unresolvable closure parameter in action callback

## Testing
- `composer install --no-interaction --prefer-dist`
- `./vendor/bin/pint app/Filament/BulkActions/HandlesSourcePlaylist.php`
- `php artisan test` *(fails: Pusher\Pusher::__construct(): Argument #1 ($auth_key) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dd9ede4883219027aec5f104d840