### PR TITLE
Add bulk action to change parent playlist

### DIFF
--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -267,6 +267,48 @@ class ChannelsRelationManager extends RelationManager
                     ->modalIcon('heroicon-o-squares-plus')
                     ->modalDescription('Add to group')
             ->modalSubmitActionLabel('Yes, add to group'),
+                Tables\Actions\BulkAction::make('change_parent_playlist')
+                    ->label('Change parent playlist')
+                    ->form(function (Collection $records) use ($ownerRecord): array {
+                        [$groups] = self::getSourcePlaylistData($records, 'channels', 'source_id');
+
+                        $playlists = $groups->flatMap(fn ($group) => self::availablePlaylistsForGroup(
+                            $ownerRecord->id,
+                            $group,
+                            'channels',
+                            'source_id',
+                        ));
+
+                        return [
+                            Forms\Components\Select::make('playlist')
+                                ->label('Parent Playlist')
+                                ->options($playlists->unique()->toArray())
+                                ->required(),
+                        ];
+                    })
+                    ->action(function (Collection $records, array $data): void {
+                        foreach ($records as $record) {
+                            $exists = Channel::where('playlist_id', (int) $data['playlist'])
+                                ->where('source_id', $record->source_id)
+                                ->exists();
+
+                            if ($exists) {
+                                $this->changeSourcePlaylist($record, (int) $data['playlist']);
+                            }
+                        }
+                    })->after(function () {
+                        FilamentNotification::make()
+                            ->success()
+                            ->title('Parent playlist updated')
+                            ->body('The parent playlist has been updated where applicable.')
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-right-left')
+                    ->modalIcon('heroicon-o-arrows-right-left')
+                    ->modalDescription('Change the parent playlist for the selected channels.')
+                    ->modalSubmitActionLabel('Yes, change parent playlist'),
             ]);
     }
 


### PR DESCRIPTION
## Summary
- allow bulk changing parent playlist for custom playlist channels
- show only eligible playlists and update matching channels

## Testing
- `./vendor/bin/pest` *(fails: file_get_contents(/workspace/m3u-editor/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e2d5eebc8321a582bba7734977a8