### PR TITLE
Trigger child sync when playlist parent changes

### DIFF
--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -217,6 +217,10 @@ class Playlist extends Model
 
                 if ($playlist->parent) {
                     $playlist->parent->refreshChildPlaylistCache();
+                    $lock = Cache::lock("sync-playlist-{$playlist->parent->id}", 5);
+                    if ($lock->get()) {
+                        SyncPlaylistChildren::dispatch($playlist->parent);
+                    }
                 }
             } elseif ($playlist->parent) {
                 $playlist->parent->refreshChildPlaylistCache();


### PR DESCRIPTION
## Summary
- sync newly assigned parent playlist by dispatching `SyncPlaylistChildren`
- guard dispatch with cache lock so multiple child updates trigger only one job

## Testing
- `vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_68c1e6e0da208321878ba4ec8cf46cb2