### PR TITLE
Restore child playlist auto-sync after parent deletion

### DIFF
--- a/app/Console/Commands/FixOrphanedPlaylists.php
+++ b/app/Console/Commands/FixOrphanedPlaylists.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Playlist;
+use Illuminate\Console\Command;
+
+class FixOrphanedPlaylists extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:fix-orphaned-playlists';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Restore auto-sync for playlists whose parents were deleted';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $count = Playlist::whereNull('parent_id')
+            ->where('auto_sync', false)
+            ->update(['auto_sync' => true]);
+
+        $this->info("Updated {$count} orphaned playlists.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -171,7 +171,11 @@ class AppServiceProvider extends ServiceProvider
             });
             Playlist::deleting(function (Playlist $playlist) {
                 // Detach any child playlists so they become standalone playlists
-                $playlist->children()->update(['parent_id' => null]);
+                // and restore their default auto-sync behaviour
+                $playlist->children()->update([
+                    'parent_id' => null,
+                    'auto_sync' => true,
+                ]);
 
                 Storage::disk('local')->deleteDirectory($playlist->folder_path);
                 if ($playlist->uploads && Storage::disk('local')->exists($playlist->uploads)) {

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -8,6 +8,10 @@ trait CreatesApplication
 {
     public function createApplication(): Application
     {
+        putenv('BROADCAST_CONNECTION=null');
+        $_ENV['BROADCAST_CONNECTION'] = 'null';
+        $_SERVER['BROADCAST_CONNECTION'] = 'null';
+
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();

--- a/tests/Feature/PlaylistDeletionAutoSyncTest.php
+++ b/tests/Feature/PlaylistDeletionAutoSyncTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\Playlist;
+use App\Models\User;
+
+it('restores auto sync for child playlists when parent deleted', function () {
+    $user = User::factory()->create();
+    $parent = Playlist::factory()->for($user)->create();
+    $child = Playlist::factory()->for($user)->create([
+        'parent_id' => $parent->id,
+    ]);
+
+    expect($child->auto_sync)->toBeFalse();
+
+    $parent->delete();
+
+    $child->refresh();
+
+    expect($child->parent_id)->toBeNull();
+    expect((bool) $child->auto_sync)->toBeTrue();
+});
+
+it('command restores auto sync for orphaned playlists', function () {
+    $user = User::factory()->create();
+    $parent = Playlist::factory()->for($user)->create();
+    $child = Playlist::factory()->for($user)->create([
+        'parent_id' => $parent->id,
+    ]);
+
+    // Simulate an orphaned playlist left with auto_sync disabled
+    $child->parent_id = null;
+    $child->save();
+
+    expect($child->auto_sync)->toBeFalse();
+
+    $this->artisan('app:fix-orphaned-playlists')->assertExitCode(0);
+
+    $child->refresh();
+
+    expect((bool) $child->auto_sync)->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,6 +16,7 @@ pest()->extend(Tests\TestCase::class);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use App\Jobs\SyncPlaylistChildren;
 
@@ -24,8 +25,10 @@ uses(RefreshDatabase::class)->in('Feature', 'Unit');
 beforeEach(function () {
     Bus::fake();
     Queue::fake();
+    Event::fake();
     Config::set('cache.default', 'array');
     Config::set('queue.default', 'sync');
+    Config::set('broadcasting.default', 'null');
     // Prevent static debounce dispatches from running
     if (! class_exists('\Mockery')) {
         return;


### PR DESCRIPTION
## Summary
- ensure deleting a parent playlist clears its children's `parent_id` and re-enables auto-sync
- add `app:fix-orphaned-playlists` command to repair existing orphaned records
- test that child playlists resume auto-sync after parent removal and via fix command

## Testing
- `./vendor/bin/pest tests/Feature/PlaylistDeletionAutoSyncTest.php` *(fails: SQLSTATE[HY000]: General error: 5 database is locked)*


------
https://chatgpt.com/codex/tasks/task_e_68c1e830ea0c8321837681ecbf71a200