### PR TITLE
fix: pass array to action arguments

### DIFF
--- a/app/Filament/BulkActions/HandlesSourcePlaylist.php
+++ b/app/Filament/BulkActions/HandlesSourcePlaylist.php
@@ -232,7 +232,9 @@ trait HandlesSourcePlaylist
                                 ->color('primary')
                                 ->button()
                                 ->extraAttributes(['class' => 'whitespace-nowrap'])
-                                ->arguments(fn (Get $get) => ['playlist' => $get('playlist')])
+                                ->arguments([
+                                    'playlist' => fn (Get $get) => $get('playlist'),
+                                ])
                                 ->form(function (Get $get, array $arguments) use ($group, $groupKey, $relation, $sourceKey, $labels) {
                                     $existing = $get("source_playlist_items.{$groupKey}") ?? [];
                                     $default = $get("source_playlists.{$groupKey}");


### PR DESCRIPTION
## Summary
- fix source playlist suffix action argument handling by providing array instead of closure

## Testing
- `./vendor/bin/pint app/Filament/BulkActions/HandlesSourcePlaylist.php`
- `./vendor/bin/pest` *(fails: Database file at path ... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f60ea3548321ab0c4f092190dd49